### PR TITLE
fix: исправлен text_color=None для CTkLabel (CTk 6.0) и добавлена прокрутка страниц визарда

### DIFF
--- a/src/ui/pages/page_comments.py
+++ b/src/ui/pages/page_comments.py
@@ -358,7 +358,8 @@ class PageComments(ctk.CTkFrame):
         for widget in [self.freq_frame, self.role_frame, self.custom_frame]:
             for child in widget.winfo_children():
                 if isinstance(child, (ctk.CTkSlider, ctk.CTkOptionMenu, ctk.CTkTextbox, ctk.CTkLabel)):
-                    child.configure(text_color=("gray" if not enabled else None))
+                    if not enabled:
+                        child.configure(text_color="gray")
                 if isinstance(child, (ctk.CTkSlider, ctk.CTkOptionMenu)):
                     child.configure(state=state)
                 if isinstance(child, ctk.CTkTextbox):

--- a/src/ui/wizard.py
+++ b/src/ui/wizard.py
@@ -69,8 +69,8 @@ class WizardController:
         self.step_labels: List[ctk.CTkLabel] = []
         self._create_step_indicator()
 
-        # Контейнер для содержимого страницы
-        self.content_frame = ctk.CTkFrame(parent)
+        # Контейнер для содержимого страницы (с прокруткой, если не помещается)
+        self.content_frame = ctk.CTkScrollableFrame(parent)
         self.content_frame.pack(fill="both", expand=True, padx=5, pady=5)
 
         # Навигационные кнопки


### PR DESCRIPTION
Два исправления:

- **page_comments**: убран вызов `configure(text_color=None)` — в CustomTkinter 6.0 `None` вызывает `ValueError`. Теперь цвет меняется только при disabled-состоянии
- **wizard**: `CTkFrame` заменён на `CTkScrollableFrame` для контейнера страниц — длинные страницы (особенно Шаг 6) теперь прокручиваются, а не обрезаются