### PR TITLE
fix: сделать Edge TTS устойчивее к NoAudioReceived и логировать сбои

### DIFF
--- a/src/core/tts_edge.py
+++ b/src/core/tts_edge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -16,6 +17,51 @@ import edge_tts
 from src.core.tts_base import TTSBackend
 
 logger = logging.getLogger(__name__)
+
+# Отдельный файл с провалившимися сегментами (текст целиком)
+_FAILURES_LOG = Path.home() / ".audiobook-generator" / "edge_tts_failures.log"
+
+
+def _log_edge_failure(
+    *,
+    voice: str,
+    rate: str,
+    segment_index: Optional[int],
+    attempt: int,
+    max_retries: int,
+    exc: BaseException,
+    text: str,
+    final: bool = False,
+) -> None:
+    """Пишет детали сбоя Edge TTS в основной лог и в failures-файл."""
+    preview = text[:200].replace("\n", " ")
+    idx = segment_index if segment_index is not None else -1
+    level = logger.error if final else logger.warning
+    level(
+        "Edge TTS %s: seg=%s attempt=%d/%d voice=%s rate=%s chars=%d err=%s text=%r",
+        "FAIL" if final else "retry",
+        idx,
+        attempt,
+        max_retries,
+        voice,
+        rate,
+        len(text),
+        f"{type(exc).__name__}: {exc}",
+        preview,
+    )
+    try:
+        _FAILURES_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with _FAILURES_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(
+                f"\n--- {datetime.now().isoformat(timespec='seconds')} "
+                f"{'FINAL' if final else 'retry'} seg={idx} "
+                f"attempt={attempt}/{max_retries} voice={voice} rate={rate} "
+                f"chars={len(text)} err={type(exc).__name__}: {exc}\n"
+            )
+            fh.write(text)
+            fh.write("\n")
+    except OSError as log_exc:
+        logger.warning("Не удалось записать edge_tts_failures.log: %s", log_exc)
 
 
 # Голоса по умолчанию для разных языков
@@ -62,7 +108,7 @@ class EdgeTTSManager(TTSBackend):
         voice: str,
         speed: float = 1.0,
         output_dir: Optional[Path] = None,
-        max_retries: int = 3,
+        max_retries: int = 5,
         retry_delay: float = 2.0,
         segment_index: Optional[int] = None,
     ) -> Path:
@@ -124,10 +170,20 @@ class EdgeTTSManager(TTSBackend):
                     timeout=SEGMENT_TIMEOUT,
                 )
 
-                logger.debug(
-                    "Синтезирован сегмент: голос=%s, длина=%d символов, файл=%s",
-                    voice, len(text), output_path.name,
-                )
+                if attempt > 1:
+                    logger.info(
+                        "Edge TTS OK после retry: seg=%s attempt=%d voice=%s chars=%d file=%s",
+                        segment_index if segment_index is not None else -1,
+                        attempt,
+                        voice,
+                        len(text),
+                        output_path.name,
+                    )
+                else:
+                    logger.debug(
+                        "Синтезирован сегмент: голос=%s, длина=%d символов, файл=%s",
+                        voice, len(text), output_path.name,
+                    )
                 return output_path
 
             except Exception as exc:
@@ -135,6 +191,7 @@ class EdgeTTSManager(TTSBackend):
                 exc_str = str(exc)
 
                 # Повторяемые ошибки: 5xx сервера + временные DNS/сетевые сбои
+                # + NoAudioReceived (Edge часто отваливается на отдельных фразах)
                 retryable_patterns = [
                     "503", "502", "500",           # Server errors
                     "Temporary failure in name resolution",  # DNS
@@ -143,27 +200,46 @@ class EdgeTTSManager(TTSBackend):
                     "Connection refused",          # Network
                     "Connection reset",            # Network
                     "Timeout", "timed out",        # Timeout
+                    "No audio was received",       # Edge TTS flake / rate-limit
                 ]
                 is_retryable = (
                     any(p in exc_str for p in retryable_patterns)
                     or isinstance(exc, (TimeoutError, asyncio.TimeoutError))
+                    or type(exc).__name__ == "NoAudioReceived"
                 )
 
                 if is_retryable and attempt < max_retries:
                     delay = retry_delay * (2 ** (attempt - 1))
-                    logger.warning(
-                        "Ошибка Edge TTS (попытка %d/%d): %s. Повтор через %.1f сек...",
-                        attempt, max_retries, exc_str, delay,
+                    _log_edge_failure(
+                        voice=voice,
+                        rate=rate,
+                        segment_index=segment_index,
+                        attempt=attempt,
+                        max_retries=max_retries,
+                        exc=exc,
+                        text=text,
+                        final=False,
                     )
+                    logger.warning("Повтор Edge TTS через %.1f сек...", delay)
                     await asyncio.sleep(delay)
                     continue
 
-                # Остальные ошибки (4xx, неверный ключ и т.д.) не повторяем
-                logger.error(
-                    "Неисправимая ошибка Edge TTS (попытка %d/%d): %s",
-                    attempt, max_retries, exc_str,
+                # Финальный провал: логируем полный текст и бросаем RuntimeError,
+                # чтобы synthesize_chapter мог подставить тишину и продолжить книгу.
+                _log_edge_failure(
+                    voice=voice,
+                    rate=rate,
+                    segment_index=segment_index,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    exc=exc,
+                    text=text,
+                    final=True,
                 )
-                raise
+                raise RuntimeError(
+                    f"Edge TTS: seg={segment_index} voice={voice} "
+                    f"chars={len(text)} после {attempt}/{max_retries}: {exc_str}"
+                ) from exc
 
         # Все попытки исчерпаны
         raise RuntimeError(
@@ -245,10 +321,11 @@ class EdgeTTSManager(TTSBackend):
                     text, self.config.main_voice, self.config.main_speed,
                     chapter_dir, segment_index=i * 2,
                 )
-            except RuntimeError as e:
+            except Exception as e:
                 logger.error(
-                    "Ошибка синтеза сегмента #%d (гл.текст): %s — генерирую тишину",
-                    i, e,
+                    "Ошибка синтеза сегмента #%d (гл.текст): %s — генерирую тишину. "
+                    "Полный текст: %s",
+                    i, e, _FAILURES_LOG,
                 )
                 silence_path = chapter_dir / f"seg_{i * 2:06d}.mp3"
                 await self._generate_silence_mp3(silence_path, duration_sec=0.5)
@@ -269,10 +346,11 @@ class EdgeTTSManager(TTSBackend):
                         self.config.comment_speed, chapter_dir,
                         segment_index=i * 2 + 1,
                     )
-                except RuntimeError as e:
+                except Exception as e:
                     logger.error(
-                        "Ошибка синтеза комментария #%d: %s — генерирую тишину",
-                        i, e,
+                        "Ошибка синтеза комментария #%d: %s — генерирую тишину. "
+                        "Полный текст: %s",
+                        i, e, _FAILURES_LOG,
                     )
                     silence_path = chapter_dir / f"seg_{i * 2 + 1:06d}.mp3"
                     await self._generate_silence_mp3(silence_path, duration_sec=0.5)


### PR DESCRIPTION
Повторные попытки при NoAudioReceived, подробный лог сегмента и полный текст в ~/.audiobook-generator/edge_tts_failures.log; после исчерпания retry — RuntimeError + тишина, чтобы не обрывать всю книгу.
