### PR TITLE
ui: поставить «Комментарии» перед «Объёмом» в мастере

### DIFF
--- a/src/ui/pages/page_comments.py
+++ b/src/ui/pages/page_comments.py
@@ -1,5 +1,5 @@
 """
-Шаг 6: Настройка частоты комментирования, выбор системного промпта и TTS-движка.
+Шаг 5: Настройка частоты комментирования, выбор системного промпта и TTS-движка.
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 # Тексты на разных языках
 COMMENTS_TEXTS = {
     "ru": {
-        "title": "Шаг 6: Настройка комментариев",
+        "title": "Шаг 5: Настройка комментариев",
         "desc": "Настройте частоту комментариев и выберите роль комментатора",
         "enabled_label": "Генерировать AI-комментарии",
         "freq_label": "Частота комментирования:",
@@ -34,7 +34,7 @@ COMMENTS_TEXTS = {
         "gender_female": "Женский",
     },
     "en": {
-        "title": "Step 6: Comment Settings",
+        "title": "Step 5: Comment Settings",
         "desc": "Set comment frequency and choose a commentator role",
         "enabled_label": "Generate AI comments",
         "freq_label": "Comment frequency:",
@@ -49,7 +49,7 @@ COMMENTS_TEXTS = {
         "gender_female": "Female",
     },
     "ja": {
-        "title": "ステップ6: コメント設定",
+        "title": "ステップ5: コメント設定",
         "desc": "コメント頻度とコメンテーターの役割を設定してください",
         "enabled_label": "AIコメントを生成",
         "freq_label": "コメント頻度:",
@@ -64,7 +64,7 @@ COMMENTS_TEXTS = {
         "gender_female": "女性",
     },
     "zh": {
-        "title": "步骤6：评论设置",
+        "title": "步骤5：评论设置",
         "desc": "设置评论频率并选择评论者角色",
         "enabled_label": "生成AI评论",
         "freq_label": "评论频率：",

--- a/src/ui/pages/page_launch.py
+++ b/src/ui/pages/page_launch.py
@@ -11,6 +11,7 @@ from typing import Callable, Optional
 import customtkinter as ctk
 
 from src.config.settings import Settings
+from src.core.fb2_parser import FB2Parser
 from src.core.tts_manager import resolve_voice
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,12 @@ LAUNCH_TEXTS = {
         "freq_label": "Комментарии",
         "freq_format": "каждые {} предложений",
         "freq_off": "Отключены",
+        "scope_label": "Объём озвучки",
+        "scope_all": "Полный",
+        "scope_single": "Глава {}",
+        "scope_range": "Главы с {} по {}",
+        "total_chapters_label": "Всего глав в файле",
+        "total_chapters_unknown": "—",
         "voice_main_label": "Голос текста",
         "voice_comment_label": "Голос комментатора",
         "output_label": "Путь сохранения",
@@ -43,6 +50,12 @@ LAUNCH_TEXTS = {
         "freq_label": "Comments",
         "freq_format": "every {} sentences",
         "freq_off": "Disabled",
+        "scope_label": "Narration scope",
+        "scope_all": "Full book",
+        "scope_single": "Chapter {}",
+        "scope_range": "Chapters {}–{}",
+        "total_chapters_label": "Total chapters in file",
+        "total_chapters_unknown": "—",
         "voice_main_label": "Text voice",
         "voice_comment_label": "Comment voice",
         "output_label": "Output path",
@@ -60,6 +73,12 @@ LAUNCH_TEXTS = {
         "freq_label": "コメント",
         "freq_format": "{}文ごと",
         "freq_off": "無効",
+        "scope_label": "ナレーション範囲",
+        "scope_all": "全章",
+        "scope_single": "第{}章",
+        "scope_range": "第{}章〜第{}章",
+        "total_chapters_label": "ファイル内の総章数",
+        "total_chapters_unknown": "—",
         "voice_main_label": "テキストの声",
         "voice_comment_label": "コメントの声",
         "output_label": "出力先",
@@ -76,6 +95,12 @@ LAUNCH_TEXTS = {
         "freq_label": "评论",
         "freq_format": "每{}句",
         "freq_off": "已禁用",
+        "scope_label": "朗读范围",
+        "scope_all": "全书",
+        "scope_single": "第{}章",
+        "scope_range": "第{}章至第{}章",
+        "total_chapters_label": "文件中总章节数",
+        "total_chapters_unknown": "—",
         "voice_main_label": "正文语音",
         "voice_comment_label": "评论语音",
         "output_label": "输出路径",
@@ -106,6 +131,7 @@ class PageLaunch(ctk.CTkFrame):
         super().__init__(parent)
         self.settings = settings
         self.on_complete = on_complete
+        self._total_chapters: Optional[int] = self._count_chapters()
 
         self._create_widgets()
 
@@ -147,10 +173,18 @@ class PageLaunch(ctk.CTkFrame):
             self.settings.tts_backend, self.settings.tts_backend
         )
 
+        total_display = (
+            str(self._total_chapters)
+            if self._total_chapters is not None
+            else t["total_chapters_unknown"]
+        )
+
         items = [
             (t["lang_label"], self._lang_display(self.settings.book_lang)),
             (t["provider_label"], self.settings.ai_provider.capitalize()),
             (t["freq_label"], self._comment_summary()),
+            (t["scope_label"], self._scope_summary()),
+            (t["total_chapters_label"], total_display),
             (t["voice_main_label"], resolve_voice(
                 self.settings.tts_backend, self.settings.book_lang, self.settings.main_gender,
             )),
@@ -223,6 +257,41 @@ class PageLaunch(ctk.CTkFrame):
         lang = self.settings.ui_lang
         t = LAUNCH_TEXTS.get(lang, LAUNCH_TEXTS["ru"])
         return t["freq_format"].format(self.settings.comment_frequency)
+
+    def _count_chapters(self) -> Optional[int]:
+        """Число глав в выбранном FB2 (для сводки)."""
+        book_path = getattr(self.settings, "book_path", "") or ""
+        if not book_path:
+            return None
+        path = Path(book_path)
+        if not path.exists():
+            return None
+        try:
+            book = FB2Parser().parse(path)
+            return len(book.chapters)
+        except Exception as exc:
+            logger.warning("Не удалось посчитать главы для сводки: %s", exc)
+            return None
+
+    def _scope_summary(self) -> str:
+        """Человекочитаемый объём озвучки по chapter_start/chapter_end."""
+        lang = self.settings.ui_lang
+        t = LAUNCH_TEXTS.get(lang, LAUNCH_TEXTS["ru"])
+        start = int(getattr(self.settings, "chapter_start", 0) or 0)
+        end = int(getattr(self.settings, "chapter_end", 0) or 0)
+
+        # Как в pipeline: 0/0 = вся книга
+        if start == 0 and end == 0:
+            return t["scope_all"]
+
+        # Одна глава: end == start + 1 (индексы 0-based / exclusive end)
+        if end == start + 1:
+            return t["scope_single"].format(start + 1)
+
+        # Диапазон: отображаем 1-based включительно
+        from_ch = start + 1
+        to_ch = end if end > 0 else (self._total_chapters or from_ch)
+        return t["scope_range"].format(from_ch, to_ch)
 
     def _get_launch_text(self) -> str:
         """Получение текста кнопки запуска."""

--- a/src/ui/pages/page_scope.py
+++ b/src/ui/pages/page_scope.py
@@ -1,5 +1,5 @@
 """
-Шаг 5: Настройка объёма озвучки (одна глава, диапазон, вся книга).
+Шаг 6: Настройка объёма озвучки (одна глава, диапазон, вся книга).
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ from src.config.settings import Settings
 # Тексты на разных языках
 SCOPE_TEXTS = {
     "ru": {
-        "title": "Шаг 5: Объём озвучки",
+        "title": "Шаг 6: Объём озвучки",
         "desc": "Выберите, какие главы книги нужно озвучить",
         "all": "Вся книга",
         "range": "Диапазон глав",
@@ -23,7 +23,7 @@ SCOPE_TEXTS = {
         "chapter_num": "Номер главы:",
     },
     "en": {
-        "title": "Step 5: Narration Scope",
+        "title": "Step 6: Narration Scope",
         "desc": "Select which chapters of the book to narrate",
         "all": "Whole book",
         "range": "Chapter range",
@@ -33,7 +33,7 @@ SCOPE_TEXTS = {
         "chapter_num": "Chapter number:",
     },
     "ja": {
-        "title": "ステップ5: ナレーション範囲",
+        "title": "ステップ6: ナレーション範囲",
         "desc": "ナレーションする章を選択してください",
         "all": "全章",
         "range": "章の範囲",
@@ -43,7 +43,7 @@ SCOPE_TEXTS = {
         "chapter_num": "章番号:",
     },
     "zh": {
-        "title": "步骤5：朗读范围",
+        "title": "步骤6：朗读范围",
         "desc": "选择需要朗读的书籍章节",
         "all": "全书",
         "range": "章节范围",

--- a/src/ui/wizard.py
+++ b/src/ui/wizard.py
@@ -26,10 +26,10 @@ logger = logging.getLogger(__name__)
 
 # Названия шагов на разных языках
 STEP_NAMES = {
-    "ru": ["Язык", "API", "О нас", "Файл", "Объём", "Комментарии", "Запуск"],
-    "en": ["Language", "API", "About", "File", "Scope", "Comments", "Launch"],
-    "ja": ["言語", "API", "概要", "ファイル", "範囲", "コメント", "開始"],
-    "zh": ["语言", "API", "关于", "文件", "范围", "评论", "启动"],
+    "ru": ["Язык", "API", "О нас", "Файл", "Комментарии", "Объём", "Запуск"],
+    "en": ["Language", "API", "About", "File", "Comments", "Scope", "Launch"],
+    "ja": ["言語", "API", "概要", "ファイル", "コメント", "範囲", "開始"],
+    "zh": ["语言", "API", "关于", "文件", "评论", "范围", "启动"],
 }
 
 # Тексты навигационных кнопок
@@ -142,8 +142,8 @@ class WizardController:
             PageAPI,
             PageLogo,
             PageFile,
-            PageScope,
             PageComments,
+            PageScope,
             PageLaunch,
         ]
 


### PR DESCRIPTION
При озвучке по главам/блокам часто нужно только сменить объём и снова запустить — комментарии и TTS при этом не трогают. Новый порядок (Файл → Комментарии → Объём → Запуск) позволяет вернуться на один шаг назад без повторного прохождения настроек комментариев.