### PR TITLE
ui/pipeline: создание аудиокниги как шаг мастера, этапы прогресса и предсказуемая отмена

### DIFF
--- a/src/core/audio_assembler.py
+++ b/src/core/audio_assembler.py
@@ -96,6 +96,7 @@ class AudioAssembler:
         self,
         segments: List[Tuple[Path, float]],
         output_path: Path,
+        fragment_callback: Optional[Callable[[int, int], None]] = None,
     ) -> Path:
         """Склейка аудиофрагментов в главу.
 
@@ -106,12 +107,14 @@ class AudioAssembler:
         Args:
             segments: Список кортежей (путь_к_аудио, пауза_перед_в_сек).
             output_path: Путь для сохранения готовой главы.
+            fragment_callback: После каждого фрагмента (готово, всего).
 
         Returns:
             Путь к готовому аудиофайлу главы.
         """
         logger.info("Склейка главы: %d фрагментов", len(segments))
         output_path.parent.mkdir(parents=True, exist_ok=True)
+        total = len(segments)
 
         with tempfile.TemporaryDirectory(prefix="chapter_") as tmp_dir:
             tmp_root = Path(tmp_dir)
@@ -127,6 +130,8 @@ class AudioAssembler:
 
                 if not audio_path.exists():
                     logger.warning("Файл не найден: %s", audio_path)
+                    if fragment_callback:
+                        fragment_callback(idx + 1, total)
                     continue
 
                 # Пре-декодируем каждый сегмент в WAV с едиными параметрами
@@ -139,6 +144,9 @@ class AudioAssembler:
                     str(wav_segment),
                 ])
                 wav_files.append(wav_segment)
+
+                if fragment_callback:
+                    fragment_callback(idx + 1, total)
 
             if not wav_files:
                 raise FileNotFoundError("Нет ни одного валидного аудиофайла для склейки главы")

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1,11 +1,10 @@
 """
 Оркестратор — координация всех модулей для создания аудиокниги.
-Управляет потоком: парсинг → разбиение → комментарии → TTS → склейка.
+Поток: парсинг → анализ сегментов → синтез → склейка глав → склейка книги.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import threading
 import time
@@ -17,8 +16,17 @@ from .fb2_parser import FB2Parser, ParsedBook
 from .sentence_splitter import SentenceSplitter
 from .comment_manager import CommentManager, CommentConfig
 from .tts_manager import TTSManager, TTSConfig
+from .tts_base import SynthesisCancelled
 from .audio_assembler import AudioAssembler
 from .checkpoint_manager import CheckpointManager, Checkpoint
+from src.utils.scope_display import (
+    STAGE_PREPARE,
+    STAGE_SYNTH,
+    STAGE_CHAPTER_MERGE,
+    STAGE_BOOK_MERGE,
+    STAGE_DONE,
+    format_progress_scope_line,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,37 +34,36 @@ logger = logging.getLogger(__name__)
 @dataclass
 class AppConfig:
     """Полная конфигурация приложения."""
-    # Пути
     book_path: Path = Path("")
     output_dir: Path = Path.home() / "audiobooks"
     work_dir: Path = Path.home() / ".audiobook-generator"
 
-    # Настройки книги
     lang: str = "ru"
     chapter_start: int = 0  # 0 = с начала
     chapter_end: int = 0    # 0 = до конца
 
-    # Комментарии
     comment_config: CommentConfig = field(default_factory=CommentConfig)
-
-    # TTS
     tts_config: TTSConfig = field(default_factory=TTSConfig)
 
 
-class Pipeline:
-    """Оркестратор процесса создания аудиокниги.
+@dataclass
+class _ChapterJob:
+    """Подготовленная глава: текст разбит, комментарии готовы."""
+    chapter_num: int
+    title: str
+    sentences: List[str]
+    comments: List[Optional[str]]
+    chapter_dir: Path
+    segment_count: int
 
-    Пример использования:
-        config = AppConfig(
-            book_path=Path("book.fb2"),
-            output_dir=Path("./output"),
-        )
-        pipeline = Pipeline(config)
-        result = await pipeline.run(
-            progress_callback=lambda c, t: print(f"{c}/{t}"),
-            cancel_event=threading.Event(),
-        )
-    """
+
+class Pipeline:
+    """Оркестратор процесса создания аудиокниги."""
+
+    _W_PREPARE = 0.08
+    _W_SYNTH = 0.72
+    _W_CH_MERGE = 0.15
+    _W_BOOK = 0.05
 
     def __init__(self, config: AppConfig):
         self.config = config
@@ -72,219 +79,309 @@ class Pipeline:
         self._chapter_audio_paths: List[Path] = []
         self._paused = False
         self._pause_event = threading.Event()
-        self._pause_event.set()  # не на паузе
-        self._cancel_event = threading.Event()  # не отменён
+        self._pause_event.set()
+        self._cancel_event = threading.Event()
 
     async def run(
         self,
-        progress_callback: Optional[Callable[[str, float], None]] = None,
+        progress_callback: Optional[Callable] = None,
         cancel_event: Optional[threading.Event] = None,
-        detail_callback: Optional[Callable[[int, int, str, str, str], None]] = None,
+        detail_callback: Optional[Callable] = None,
     ) -> Path:
-        """Запуск полного процесса создания аудиокниги.
+        """Парсинг → анализ всех сегментов → синтез → склейка глав → склейка книги.
 
-        Args:
-            progress_callback: Колбэк прогресса (статус, процент 0.0-1.0).
-            cancel_event: Событие отмены.
-            detail_callback: Колбэк деталей синтеза (номер, всего, текст, голос, движок).
-
-        Returns:
-            Путь к финальному MP3-файлу.
-
-        Raises:
-            ValueError: Если книга не загружена.
+        При отмене после частичного синтеза склеивает готовые главы в partial-файл.
         """
         if cancel_event is None:
             cancel_event = self._cancel_event
 
         self._temp_dir = self.config.work_dir / "temp_audio"
+        self._temp_dir.mkdir(parents=True, exist_ok=True)
         self._chapter_audio_paths = []
+        success = False
 
         try:
-            # Шаг 1: Парсинг FB2
-            self._report(progress_callback, "Парсинг FB2-файла...", 0.0)
+            self._report(progress_callback, "Парсинг FB2-файла…", 0.0, stage=STAGE_PREPARE)
             book = self.fb2_parser.parse(self.config.book_path)
             self._book = book
-
             if not book.chapters:
                 raise ValueError("В книге нет глав")
 
             total_chapters = len(book.chapters)
-            start_chapter = self.config.chapter_start or 0
-            end_chapter = self.config.chapter_end or total_chapters
+            cfg_start = self.config.chapter_start or 0
+            cfg_end = self.config.chapter_end or 0
+            start_chapter = cfg_start
+            end_chapter = cfg_end or total_chapters
             chapters_to_process = book.chapters[start_chapter:end_chapter]
+            if not chapters_to_process:
+                raise ValueError("В выбранном диапазоне нет глав")
+
+            ui_lang = self.config.lang or "ru"
+
+            def _scope_line(chapter_1based: Optional[int] = None) -> str:
+                return format_progress_scope_line(
+                    chapter_current=chapter_1based,
+                    chapter_start=cfg_start,
+                    chapter_end=cfg_end,
+                    total_chapters=total_chapters,
+                    lang=ui_lang,
+                )
 
             self._report(
                 progress_callback,
-                f"Книга: '{book.metadata.title}', глав: {len(chapters_to_process)}",
-                0.05,
+                f"Книга: «{book.metadata.title}» — анализ сегментов…",
+                0.02,
+                stage=STAGE_PREPARE,
+                scope_line=_scope_line(),
             )
 
-            # Проверка чекпоинта
-            checkpoint = self.checkpoint_manager.load()
-            resume_from = 0
-            if checkpoint and checkpoint.book_path == str(self.config.book_path):
-                resume_from = checkpoint.last_completed_chapter + 1
-
-                # Если чекпоинт указывает на главу вне текущего диапазона — очищаем и начинаем сначала
-                if resume_from >= end_chapter:
-                    logger.warning(
-                        "Чекпоинт (глава %d) вне диапазона [%d, %d), очищаю и начинаю сначала",
-                        checkpoint.last_completed_chapter, start_chapter, end_chapter,
-                    )
-                    self.checkpoint_manager.clear()
-                    resume_from = 0
-                else:
-                    self._report(
-                        progress_callback,
-                        f"Восстановление с главы {resume_from + 1}...",
-                        0.05,
-                    )
-
-            # Шаг 2-4: Обработка каждой главы
+            jobs: List[_ChapterJob] = []
+            n_ch = len(chapters_to_process)
             for idx, chapter in enumerate(chapters_to_process):
                 if cancel_event.is_set():
-                    self._report(progress_callback, "Процесс отменён", 0.0)
                     break
-
-                # Ожидание снятия паузы
                 self._pause_event.wait()
 
                 chapter_num = start_chapter + idx
-                if chapter_num < resume_from:
-                    continue
-
-                chapter_progress = 0.1 + (idx / len(chapters_to_process)) * 0.8
-
-                # Разбиение на предложения
+                scope_now = _scope_line(chapter_num + 1)
+                prep_prog = 0.02 + (idx / n_ch) * (self._W_PREPARE - 0.02)
                 self._report(
                     progress_callback,
-                    f"Глава {chapter_num + 1}/{total_chapters}: разбиение на предложения...",
-                    chapter_progress,
+                    "Разбиение на предложения…",
+                    prep_prog,
+                    stage=STAGE_PREPARE,
+                    scope_line=scope_now,
                 )
+
                 sentences = self.sentence_splitter.split(
                     " ".join(chapter.paragraphs),
                     book.metadata.lang,
                 )
-
                 if not sentences:
                     logger.warning("Глава %d пуста, пропуск", chapter_num + 1)
                     continue
 
-                # Генерация комментариев (если включены)
                 if self.config.comment_config.enabled:
                     self._report(
                         progress_callback,
-                        f"Глава {chapter_num + 1}/{total_chapters}: генерация комментариев...",
-                        chapter_progress + 0.05,
+                        "Генерация комментариев…",
+                        prep_prog,
+                        stage=STAGE_PREPARE,
+                        scope_line=scope_now,
                     )
                     comments = await self.comment_manager.generate_all(
-                        sentences,
-                        progress_callback=None,
+                        sentences, progress_callback=None,
                     )
                 else:
                     comments = [None] * len(sentences)
 
-                # Синтез речи
-                self._report(
-                    progress_callback,
-                    f"Глава {chapter_num + 1}/{total_chapters}: синтез речи...",
-                    chapter_progress + 0.2,
-                )
-
+                seg_count = len(sentences) + sum(1 for c in comments if c)
                 chapter_dir = self._temp_dir / f"chapter_{chapter_num:04d}"
-                await self.tts_manager.synthesize_chapter(
-                    text_segments=sentences,
-                    comment_segments=comments,
+                chapter_dir.mkdir(parents=True, exist_ok=True)
+                jobs.append(_ChapterJob(
+                    chapter_num=chapter_num,
+                    title=chapter.title or f"Глава {chapter_num + 1}",
+                    sentences=sentences,
+                    comments=comments,
                     chapter_dir=chapter_dir,
-                    detail_callback=detail_callback,
-                )
+                    segment_count=seg_count,
+                ))
 
-                # Склейка аудиофрагментов главы
+            if not jobs:
+                if cancel_event.is_set():
+                    raise SynthesisCancelled("Создание аудиокниги отменено")
+                raise ValueError("Нет глав для озвучки после разбиения")
+
+            total_segments = sum(j.segment_count for j in jobs)
+            n_jobs = len(jobs)
+            self._report(
+                progress_callback,
+                f"Сегментов к синтезу: {total_segments} в {n_jobs} гл.",
+                self._W_PREPARE,
+                stage=STAGE_PREPARE,
+                scope_line=_scope_line(),
+                segment_index=0,
+                segment_total=total_segments,
+            )
+
+            synthesized: List[_ChapterJob] = []
+            global_done = 0
+
+            for job_idx, job in enumerate(jobs):
+                if cancel_event.is_set():
+                    break
+                self._pause_event.wait()
+
+                scope_now = _scope_line(job.chapter_num + 1)
                 self._report(
                     progress_callback,
-                    f"Глава {chapter_num + 1}/{total_chapters}: склейка аудио...",
-                    chapter_progress + 0.4,
+                    f"Синтез главы {job_idx + 1}/{n_jobs}…",
+                    self._W_PREPARE + self._W_SYNTH * (global_done / max(total_segments, 1)),
+                    stage=STAGE_SYNTH,
+                    scope_line=scope_now,
+                    segment_index=global_done,
+                    segment_total=total_segments,
                 )
 
-                chapter_audio = await self._assemble_chapter_audio(
-                    sentences, comments, chapter_dir, chapter_num,
-                )
-                self._chapter_audio_paths.append(chapter_audio)
+                seg_base = global_done
 
-                # Сохранение чекпоинта
-                config_dict = {
-                    "book_path": str(self.config.book_path),
-                    "lang": self.config.lang,
-                    "comment_frequency": self.config.comment_config.frequency,
-                    "provider": self.config.comment_config.provider,
-                }
+                def _detail_cb(
+                    completed: int,
+                    total: int,
+                    text: str,
+                    voice: str,
+                    backend: str,
+                    *,
+                    _base=seg_base,
+                    _scope=scope_now,
+                ):
+                    # completed — номер текущего (ещё не завершённого) сегмента в главе
+                    current = _base + completed
+                    prog = self._W_PREPARE + self._W_SYNTH * (
+                        (_base + completed - 1) / max(total_segments, 1)
+                    )
+                    if progress_callback:
+                        progress_callback(
+                            f"Сегмент {current}/{total_segments}",
+                            prog,
+                            stage=STAGE_SYNTH,
+                            scope_line=_scope,
+                            current_text=text,
+                            voice=voice,
+                            engine=backend,
+                            segment_index=current,
+                            segment_total=total_segments,
+                        )
+                    if detail_callback:
+                        detail_callback(current, total_segments, text, voice, backend)
+
+                def _seg_progress(
+                    completed: int,
+                    total: int,
+                    *,
+                    _base=seg_base,
+                    _scope=scope_now,
+                ):
+                    # completed — число завершённых сегментов в текущей главе
+                    finished = _base + completed
+                    prog = self._W_PREPARE + self._W_SYNTH * (
+                        finished / max(total_segments, 1)
+                    )
+                    if progress_callback:
+                        progress_callback(
+                            f"Сегмент {finished}/{total_segments}",
+                            prog,
+                            stage=STAGE_SYNTH,
+                            scope_line=_scope,
+                            segment_index=finished,
+                            segment_total=total_segments,
+                        )
+
+                await self.tts_manager.synthesize_chapter(
+                    text_segments=job.sentences,
+                    comment_segments=job.comments,
+                    chapter_dir=job.chapter_dir,
+                    progress_callback=_seg_progress,
+                    detail_callback=_detail_cb,
+                )
+                global_done += job.segment_count
+                synthesized.append(job)
+
                 self.checkpoint_manager.save(Checkpoint(
                     book_path=str(self.config.book_path),
-                    last_completed_chapter=chapter_num,
+                    last_completed_chapter=job.chapter_num,
                     total_chapters=total_chapters,
-                    config_hash=CheckpointManager.compute_config_hash(config_dict),
+                    config_hash=CheckpointManager.compute_config_hash({
+                        "book_path": str(self.config.book_path),
+                        "lang": self.config.lang,
+                        "comment_frequency": self.config.comment_config.frequency,
+                        "provider": self.config.comment_config.provider,
+                    }),
                     timestamp=time.time(),
                     output_dir=str(self._temp_dir),
                 ))
 
-            # Шаг 5: Склейка книги
-            if self._chapter_audio_paths:
-                if cancel_event.is_set():
-                    # Пользователь отменил процесс, но часть глав уже готова
-                    self._report(
-                        progress_callback,
-                        "Процесс отменён. Готовые главы не склеены в книгу.",
-                        0.0,
-                    )
-                    return Path("")
-                else:
-                    self._report(
-                        progress_callback,
-                        "Склейка всех глав в аудиокнигу...",
-                        0.95,
-                    )
+            canceled = cancel_event.is_set()
+            if not synthesized:
+                raise SynthesisCancelled("Создание аудиокниги отменено") if canceled else ValueError(
+                    "Нет синтезированных глав"
+                )
 
-                    output_filename = f"{book.metadata.title}.mp3"
-                    # Очищаем имя файла от недопустимых символов
-                    output_filename = "".join(
-                        c for c in output_filename
-                        if c.isalnum() or c in " .-_()"
-                    ).strip()
+            self._chapter_audio_paths = []
+            n_syn = len(synthesized)
+            for midx, job in enumerate(synthesized):
+                self._pause_event.wait()
+                scope_now = _scope_line(job.chapter_num + 1)
+                prog = (
+                    self._W_PREPARE + self._W_SYNTH
+                    + self._W_CH_MERGE * (midx / max(n_syn, 1))
+                )
+                self._report(
+                    progress_callback,
+                    f"Склейка главы {midx + 1}/{n_syn}…",
+                    prog,
+                    stage=STAGE_CHAPTER_MERGE,
+                    scope_line=scope_now,
+                    segment_index=midx + 1,
+                    segment_total=n_syn,
+                )
+                chapter_audio = await self._assemble_chapter_audio(
+                    job.sentences, job.comments, job.chapter_dir, job.chapter_num,
+                )
+                self._chapter_audio_paths.append(chapter_audio)
 
-                    output_path = self.config.output_dir / output_filename
-                    self.audio_assembler.assemble_book(
-                        self._chapter_audio_paths,
-                        output_path,
-                    )
+            if not self._chapter_audio_paths:
+                raise ValueError("Не удалось склеить ни одной главы")
 
-                    # Очистка чекпоинта
-                    self.checkpoint_manager.clear()
+            partial = canceled or len(synthesized) < n_jobs
+            self._report(
+                progress_callback,
+                "Склеивание книги суммарно…"
+                + (" (частичный результат)" if partial else ""),
+                0.95,
+                stage=STAGE_BOOK_MERGE,
+                scope_line=_scope_line(),
+                segment_index=len(self._chapter_audio_paths),
+                segment_total=n_jobs,
+            )
 
-                    self._report(
-                        progress_callback,
-                        f"Аудиокнига готова: {output_path}",
-                        1.0,
-                    )
+            title = book.metadata.title or "audiobook"
+            if partial:
+                first = synthesized[0].chapter_num + 1
+                last = (
+                    synthesized[len(self._chapter_audio_paths) - 1].chapter_num + 1
+                )
+                title = f"{title} (главы {first}-{last})"
 
-                    return output_path
+            output_filename = "".join(
+                c for c in f"{title}.mp3" if c.isalnum() or c in " .-_()"
+            ).strip()
+            self.config.output_dir.mkdir(parents=True, exist_ok=True)
+            output_path = self.config.output_dir / output_filename
+            self.audio_assembler.assemble_book(
+                self._chapter_audio_paths,
+                output_path,
+            )
 
-            else:
-                if cancel_event.is_set():
-                    raise ValueError("Создание аудиокниги отменено")
-                else:
-                    raise ValueError("Не удалось создать аудиокнигу: нет обработанных глав")
+            success = True
+            msg = (
+                f"Частичная аудиокнига готова: {output_path}"
+                if partial else f"Аудиокнига готова: {output_path}"
+            )
+            self._report(
+                progress_callback, msg, 1.0,
+                stage=STAGE_DONE, scope_line=_scope_line(),
+            )
+            return output_path
 
         finally:
-            # Очистка временных файлов
             if self._temp_dir and self._temp_dir.exists():
-                self.audio_assembler.cleanup_temp_files(self._temp_dir)
-
-            # Очищаем чекпоинт при любом прерывании (кроме успешного завершения):
-            # временные файлы удалены, так что чекпоинт бесполезен.
-            # Если дошли до return output_path в строке 245 — clear() уже вызван,
-            # вызывать повторно безвредно (clear проверяет exists()).
+                try:
+                    self.audio_assembler.cleanup_temp_files(self._temp_dir)
+                except Exception as exc:
+                    logger.warning("Очистка temp не удалась: %s", exc)
             self.checkpoint_manager.clear()
+
 
     async def _assemble_chapter_audio(
         self,
@@ -349,14 +446,19 @@ class Pipeline:
 
     def _report(
         self,
-        callback: Optional[Callable[[str, float], None]],
+        callback: Optional[Callable],
         message: str,
         progress: float,
+        **details,
     ):
         """Отправка отчёта о прогрессе."""
         if callback:
-            callback(message, progress)
-        logger.info("[%.0f%%] %s", progress * 100, message)
+            try:
+                callback(message, progress, **details)
+            except TypeError:
+                callback(message, progress)
+        stage = details.get("stage", "")
+        logger.info("[%.0f%%]%s %s", progress * 100, f" [{stage}]" if stage else "", message)
 
     async def close(self):
         """Освобождение ресурсов."""

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -309,26 +309,53 @@ class Pipeline:
 
             self._chapter_audio_paths = []
             n_syn = len(synthesized)
+            total_merge_frags = sum(j.segment_count for j in synthesized)
+            merge_done = 0
+
+            self._report(
+                progress_callback,
+                f"Склейка глав: сегментов {total_merge_frags}…",
+                self._W_PREPARE + self._W_SYNTH,
+                stage=STAGE_CHAPTER_MERGE,
+                scope_line=_scope_line(),
+                segment_index=0,
+                segment_total=total_merge_frags,
+            )
+
             for midx, job in enumerate(synthesized):
                 self._pause_event.wait()
                 scope_now = _scope_line(job.chapter_num + 1)
-                prog = (
-                    self._W_PREPARE + self._W_SYNTH
-                    + self._W_CH_MERGE * (midx / max(n_syn, 1))
-                )
-                self._report(
-                    progress_callback,
-                    f"Склейка главы {midx + 1}/{n_syn}…",
-                    prog,
-                    stage=STAGE_CHAPTER_MERGE,
-                    scope_line=scope_now,
-                    segment_index=midx + 1,
-                    segment_total=n_syn,
-                )
+
+                def _frag_progress(
+                    completed: int,
+                    total: int,
+                    *,
+                    _base=merge_done,
+                    _scope=scope_now,
+                    _midx=midx,
+                ):
+                    finished = _base + completed
+                    prog = (
+                        self._W_PREPARE + self._W_SYNTH
+                        + self._W_CH_MERGE * (finished / max(total_merge_frags, 1))
+                    )
+                    if progress_callback:
+                        progress_callback(
+                            f"Склейка главы {_midx + 1}/{n_syn}: "
+                            f"сегмент {finished}/{total_merge_frags}",
+                            prog,
+                            stage=STAGE_CHAPTER_MERGE,
+                            scope_line=_scope,
+                            segment_index=finished,
+                            segment_total=total_merge_frags,
+                        )
+
                 chapter_audio = await self._assemble_chapter_audio(
                     job.sentences, job.comments, job.chapter_dir, job.chapter_num,
+                    fragment_callback=_frag_progress,
                 )
                 self._chapter_audio_paths.append(chapter_audio)
+                merge_done += job.segment_count
 
             if not self._chapter_audio_paths:
                 raise ValueError("Не удалось склеить ни одной главы")
@@ -389,6 +416,7 @@ class Pipeline:
         comments: List[Optional[str]],
         chapter_dir: Path,
         chapter_num: int,
+        fragment_callback: Optional[Callable[[int, int], None]] = None,
     ) -> Path:
         """Сборка аудиофрагментов главы в один файл."""
         segments: List[Tuple[Path, float]] = []
@@ -416,7 +444,11 @@ class Pipeline:
                     segments[-1] = (segments[-1][0], tts_cfg.pause_after_comment)
 
         chapter_output = self._temp_dir / f"chapter_{chapter_num:04d}_audio.wav"
-        return self.audio_assembler.assemble_chapter(segments, chapter_output)
+        return self.audio_assembler.assemble_chapter(
+            segments,
+            chapter_output,
+            fragment_callback=fragment_callback,
+        )
 
     def pause(self):
         """Поставить процесс на паузу."""

--- a/src/core/tts_base.py
+++ b/src/core/tts_base.py
@@ -10,6 +10,10 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 
+class SynthesisCancelled(Exception):
+    """Пользователь отменил синтез / создание аудиокниги."""
+
+
 class TTSBackend(ABC):
     """Интерфейс движка синтеза речи.
 

--- a/src/core/tts_edge.py
+++ b/src/core/tts_edge.py
@@ -8,14 +8,60 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import edge_tts
 
-from src.core.tts_base import TTSBackend
+from src.core.tts_base import SynthesisCancelled, TTSBackend
 
 logger = logging.getLogger(__name__)
+
+# Отдельный файл с провалившимися сегментами (текст целиком)
+_FAILURES_LOG = Path.home() / ".audiobook-generator" / "edge_tts_failures.log"
+
+
+def _log_edge_failure(
+    *,
+    voice: str,
+    rate: str,
+    segment_index: Optional[int],
+    attempt: int,
+    max_retries: int,
+    exc: BaseException,
+    text: str,
+    final: bool = False,
+) -> None:
+    """Пишет детали сбоя Edge TTS в основной лог и в failures-файл."""
+    preview = text[:200].replace("\n", " ")
+    idx = segment_index if segment_index is not None else -1
+    level = logger.error if final else logger.warning
+    level(
+        "Edge TTS %s: seg=%s attempt=%d/%d voice=%s rate=%s chars=%d err=%s text=%r",
+        "FAIL" if final else "retry",
+        idx,
+        attempt,
+        max_retries,
+        voice,
+        rate,
+        len(text),
+        f"{type(exc).__name__}: {exc}",
+        preview,
+    )
+    try:
+        _FAILURES_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with _FAILURES_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(
+                f"\n--- {datetime.now().isoformat(timespec='seconds')} "
+                f"{'FINAL' if final else 'retry'} seg={idx} "
+                f"attempt={attempt}/{max_retries} voice={voice} rate={rate} "
+                f"chars={len(text)} err={type(exc).__name__}: {exc}\n"
+            )
+            fh.write(text)
+            fh.write("\n")
+    except OSError as log_exc:
+        logger.warning("Не удалось записать edge_tts_failures.log: %s", log_exc)
 
 
 # Голоса по умолчанию для разных языков
@@ -55,6 +101,14 @@ class EdgeTTSManager(TTSBackend):
         # Сохраняем голоса для быстрого доступа из колбэков
         self._main_voice_name = ""
         self._comment_voice_name = ""
+        self._cancel_event = None
+
+    def bind_cancel_event(self, event) -> None:
+        self._cancel_event = event
+
+    def _raise_if_canceled(self) -> None:
+        if self._cancel_event is not None and self._cancel_event.is_set():
+            raise SynthesisCancelled("Создание аудиокниги отменено")
 
     async def synthesize_segment(
         self,
@@ -62,7 +116,7 @@ class EdgeTTSManager(TTSBackend):
         voice: str,
         speed: float = 1.0,
         output_dir: Optional[Path] = None,
-        max_retries: int = 3,
+        max_retries: int = 5,
         retry_delay: float = 2.0,
         segment_index: Optional[int] = None,
     ) -> Path:
@@ -117,6 +171,7 @@ class EdgeTTSManager(TTSBackend):
 
         last_exception: Optional[Exception] = None
         for attempt in range(1, max_retries + 1):
+            self._raise_if_canceled()
             try:
                 communicate = edge_tts.Communicate(text, voice, rate=rate)
                 await asyncio.wait_for(
@@ -124,17 +179,30 @@ class EdgeTTSManager(TTSBackend):
                     timeout=SEGMENT_TIMEOUT,
                 )
 
-                logger.debug(
-                    "Синтезирован сегмент: голос=%s, длина=%d символов, файл=%s",
-                    voice, len(text), output_path.name,
-                )
+                if attempt > 1:
+                    logger.info(
+                        "Edge TTS OK после retry: seg=%s attempt=%d voice=%s chars=%d file=%s",
+                        segment_index if segment_index is not None else -1,
+                        attempt,
+                        voice,
+                        len(text),
+                        output_path.name,
+                    )
+                else:
+                    logger.debug(
+                        "Синтезирован сегмент: голос=%s, длина=%d символов, файл=%s",
+                        voice, len(text), output_path.name,
+                    )
                 return output_path
 
+            except SynthesisCancelled:
+                raise
             except Exception as exc:
                 last_exception = exc
                 exc_str = str(exc)
 
                 # Повторяемые ошибки: 5xx сервера + временные DNS/сетевые сбои
+                # + NoAudioReceived (Edge часто отваливается на отдельных фразах)
                 retryable_patterns = [
                     "503", "502", "500",           # Server errors
                     "Temporary failure in name resolution",  # DNS
@@ -143,27 +211,53 @@ class EdgeTTSManager(TTSBackend):
                     "Connection refused",          # Network
                     "Connection reset",            # Network
                     "Timeout", "timed out",        # Timeout
+                    "No audio was received",       # Edge TTS flake / rate-limit
                 ]
                 is_retryable = (
                     any(p in exc_str for p in retryable_patterns)
                     or isinstance(exc, (TimeoutError, asyncio.TimeoutError))
+                    or type(exc).__name__ == "NoAudioReceived"
                 )
 
                 if is_retryable and attempt < max_retries:
+                    self._raise_if_canceled()
                     delay = retry_delay * (2 ** (attempt - 1))
-                    logger.warning(
-                        "Ошибка Edge TTS (попытка %d/%d): %s. Повтор через %.1f сек...",
-                        attempt, max_retries, exc_str, delay,
+                    _log_edge_failure(
+                        voice=voice,
+                        rate=rate,
+                        segment_index=segment_index,
+                        attempt=attempt,
+                        max_retries=max_retries,
+                        exc=exc,
+                        text=text,
+                        final=False,
                     )
-                    await asyncio.sleep(delay)
+                    logger.warning("Повтор Edge TTS через %.1f сек...", delay)
+                    # Прерываемый sleep: проверяем отмену каждую секунду
+                    remaining = delay
+                    while remaining > 0:
+                        self._raise_if_canceled()
+                        step = min(0.25, remaining)
+                        await asyncio.sleep(step)
+                        remaining -= step
                     continue
 
-                # Остальные ошибки (4xx, неверный ключ и т.д.) не повторяем
-                logger.error(
-                    "Неисправимая ошибка Edge TTS (попытка %d/%d): %s",
-                    attempt, max_retries, exc_str,
+                # Финальный провал: логируем полный текст и бросаем RuntimeError,
+                # чтобы synthesize_chapter мог подставить тишину и продолжить книгу.
+                _log_edge_failure(
+                    voice=voice,
+                    rate=rate,
+                    segment_index=segment_index,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    exc=exc,
+                    text=text,
+                    final=True,
                 )
-                raise
+                raise RuntimeError(
+                    f"Edge TTS: seg={segment_index} voice={voice} "
+                    f"chars={len(text)} после {attempt}/{max_retries}: {exc_str}"
+                ) from exc
 
         # Все попытки исчерпаны
         raise RuntimeError(
@@ -238,6 +332,7 @@ class EdgeTTSManager(TTSBackend):
                 detail_callback(completed + 1, total, preview, seg_voice, "edge")
 
         for i, text in enumerate(text_segments):
+            self._raise_if_canceled()
             # Основной текст
             _report_segment(text, self.config.main_voice)
             try:
@@ -245,10 +340,13 @@ class EdgeTTSManager(TTSBackend):
                     text, self.config.main_voice, self.config.main_speed,
                     chapter_dir, segment_index=i * 2,
                 )
-            except RuntimeError as e:
+            except SynthesisCancelled:
+                raise
+            except Exception as e:
                 logger.error(
-                    "Ошибка синтеза сегмента #%d (гл.текст): %s — генерирую тишину",
-                    i, e,
+                    "Ошибка синтеза сегмента #%d (гл.текст): %s — генерирую тишину. "
+                    "Полный текст: %s",
+                    i, e, _FAILURES_LOG,
                 )
                 silence_path = chapter_dir / f"seg_{i * 2:06d}.mp3"
                 await self._generate_silence_mp3(silence_path, duration_sec=0.5)
@@ -261,6 +359,7 @@ class EdgeTTSManager(TTSBackend):
 
             # Комментарий (если есть для этого сегмента)
             if i < len(comment_segments) and comment_segments[i]:
+                self._raise_if_canceled()
                 comment = comment_segments[i]
                 _report_segment(comment, self.config.comment_voice)
                 try:
@@ -269,10 +368,13 @@ class EdgeTTSManager(TTSBackend):
                         self.config.comment_speed, chapter_dir,
                         segment_index=i * 2 + 1,
                     )
-                except RuntimeError as e:
+                except SynthesisCancelled:
+                    raise
+                except Exception as e:
                     logger.error(
-                        "Ошибка синтеза комментария #%d: %s — генерирую тишину",
-                        i, e,
+                        "Ошибка синтеза комментария #%d: %s — генерирую тишину. "
+                        "Полный текст: %s",
+                        i, e, _FAILURES_LOG,
                     )
                     silence_path = chapter_dir / f"seg_{i * 2 + 1:06d}.mp3"
                     await self._generate_silence_mp3(silence_path, duration_sec=0.5)

--- a/src/core/tts_manager.py
+++ b/src/core/tts_manager.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from src.core.tts_base import TTSBackend
+from src.core.tts_base import SynthesisCancelled, TTSBackend
 
 logger = logging.getLogger(__name__)
 
@@ -92,10 +93,21 @@ class TTSManager:
     def __init__(self, config: TTSConfig):
         self.config = config
         self._backend: Optional[TTSBackend] = None
+        self._cancel_event: Optional[threading.Event] = None
+
+    def bind_cancel_event(self, event: Optional[threading.Event]) -> None:
+        """Привязать событие отмены (проверяется между сегментами и retry)."""
+        self._cancel_event = event
+
+    def raise_if_canceled(self) -> None:
+        if self._cancel_event is not None and self._cancel_event.is_set():
+            raise SynthesisCancelled("Создание аудиокниги отменено")
 
     async def _get_backend(self) -> TTSBackend:
         """Ленивая инициализация бэкенда."""
         if self._backend is not None:
+            if hasattr(self._backend, "bind_cancel_event"):
+                self._backend.bind_cancel_event(self._cancel_event)
             return self._backend
 
         if self.config.backend == "edge":
@@ -112,6 +124,9 @@ class TTSManager:
             self._backend = SileroTTSManager(self.config)
         else:
             raise ValueError(f"Неизвестный TTS-бэкенд: {self.config.backend}")
+
+        if hasattr(self._backend, "bind_cancel_event"):
+            self._backend.bind_cancel_event(self._cancel_event)
 
         logger.info("TTS бэкенд: %s", BACKEND_NAMES.get(self.config.backend, self.config.backend))
         return self._backend

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -19,8 +19,9 @@ from src.config.settings import Settings, load_settings, save_settings
 from src.config.key_manager import KeyManager
 from src.core.comment_manager import CommentConfig
 from src.core.pipeline import AppConfig, Pipeline
+from src.core.tts_base import SynthesisCancelled
 from src.core.tts_manager import TTSConfig, resolve_voice
-from src.ui.progress_window import ProgressWindow
+from src.ui.pages.page_create import PageCreate
 from src.ui.wizard import WizardController
 
 logger = logging.getLogger(__name__)
@@ -65,8 +66,10 @@ class AudiobookApp(ctk.CTk):
         self.settings = settings or load_settings()
         self.wizard: Optional[WizardController] = None
         self._pipeline: Optional[Pipeline] = None
-        self._progress_window: Optional[ProgressWindow] = None
+        self._progress_page: Optional[PageCreate] = None
         self._pipeline_thread: Optional[threading.Thread] = None
+        self._pipeline_started = False
+        self._user_canceled = False
         # Единая очередь для ВСЕХ сообщений из pipeline-потока
         self._msg_queue: queue.Queue = queue.Queue()
 
@@ -156,39 +159,34 @@ class AudiobookApp(ctk.CTk):
         self.geometry(f"{width}x{height}+{x}+{y}")
 
     def on_wizard_complete(self):
-        """Обработчик завершения мастера — запуск создания аудиокниги."""
-        logger.info("Мастер завершён, запуск процесса создания аудиокниги")
-        # Сохраняем настройки
+        """Старт создания: вызывается со шага «Создание» (PageCreate)."""
+        if self._pipeline_thread and self._pipeline_thread.is_alive():
+            logger.warning("Pipeline ещё работает или завершается — повторный старт пропущен")
+            return
+
+        logger.info("Запуск процесса создания аудиокниги")
         save_settings(self.settings)
 
-        # Создаём новую очередь для этого запуска
+        page = self.wizard.get_current_page() if self.wizard else None
+        if not isinstance(page, PageCreate):
+            logger.error("Шаг Создание не активен — pipeline не запущен")
+            return
+
+        self._progress_page = page
+        self._pipeline_started = True
+        self._user_canceled = False
         self._msg_queue = queue.Queue()
 
-        # Открываем окно прогресса
-        self._progress_window = ProgressWindow(self)
-        self._progress_window.set_pause_callback(self._on_pause)
-        self._progress_window.set_resume_callback(self._on_resume)
-        self._progress_window.set_cancel_callback(self._on_cancel)
+        page.set_pause_callback(self._on_pause)
+        page.set_resume_callback(self._on_resume)
+        page.set_cancel_callback(self._on_cancel)
+        page._do_update_progress("Запуск процесса…", 0.0)
 
-        # Принудительно отрисовываем окно (в главном потоке — безопасно)
-        self._progress_window.update()
-        self.update()
-
-        # Показываем начальный статус (в главном потоке — безопасно)
-        self._progress_window._do_update_progress("Запуск процесса...", 0.0)
-        self._progress_window.update()
-        self.update()
-
-        # Запускаем pipeline в отдельном потоке
         self._pipeline_thread = threading.Thread(
             target=self._run_pipeline,
             daemon=True,
         )
         self._pipeline_thread.start()
-
-        # Запускаем watchdog-опрос очереди в главном потоке
-        # Это ЕДИНСТВЕННЫЙ безопасный способ коммуникации между потоками
-        # в PyInstaller --windowed сборке
         self.after(100, self._poll_msg_queue)
 
     def _poll_msg_queue(self):
@@ -214,43 +212,62 @@ class AudiobookApp(ctk.CTk):
                     engine = msg[5] if len(msg) > 5 else None
                     seg_idx = msg[6] if len(msg) > 6 else None
                     seg_total = msg[7] if len(msg) > 7 else None
-                    if self._progress_window:
-                        self._progress_window._do_update_progress(
+                    stage = msg[8] if len(msg) > 8 else None
+                    scope_line = msg[9] if len(msg) > 9 else None
+                    if self._progress_page:
+                        self._progress_page._do_update_progress(
                             status, progress,
                             current_text=current_text,
                             voice=voice,
                             engine=engine,
                             segment_index=seg_idx,
                             segment_total=seg_total,
+                            stage=stage,
+                            scope_line=scope_line,
                         )
+
+                elif msg_type == "canceled":
+                    _, cancel_msg = msg
+                    logger.info("Pipeline отменён: %s", cancel_msg)
+                    self._pipeline_started = False
+                    if self._progress_page:
+                        self._progress_page._do_update_progress(
+                            f"❌ {cancel_msg}", 0.0,
+                        )
+                        self._progress_page.show_finished(ok=False)
 
                 elif msg_type == "error":
                     # (type, err_msg)
                     _, err_msg = msg
                     logger.error("Ошибка pipeline: %s", err_msg)
-                    if self._progress_window:
-                        self._progress_window._do_update_progress(
+                    self._pipeline_started = False
+                    if self._progress_page:
+                        self._progress_page._do_update_progress(
                             f"❌ Ошибка: {err_msg}", 0.0
                         )
-                        self._progress_window.show_close_button()
+                        self._progress_page.show_finished(ok=False)
 
                 elif msg_type == "success":
                     # (type, message)
                     _, message = msg
                     logger.info("Pipeline завершён: %s", message)
-                    if self._progress_window:
-                        self._progress_window._do_update_progress(message, 1.0)
-                        self._progress_window.show_close_button()
+                    self._pipeline_started = False
+                    if self._progress_page:
+                        self._progress_page._do_update_progress(
+                            message, 1.0, stage="done",
+                        )
+                        self._progress_page.show_finished(ok=True)
 
                 elif msg_type == "fatal":
                     # (type, err_msg)
                     _, err_msg = msg
                     logger.error("Критическая ошибка pipeline: %s", err_msg)
-                    if self._progress_window:
-                        self._progress_window._do_update_progress(
+                    self._pipeline_started = False
+                    if self._progress_page:
+                        self._progress_page._do_update_progress(
                             f"❌ Критическая ошибка: {err_msg}", 0.0
                         )
-                        self._progress_window.show_close_button()
+                        self._progress_page.show_finished(ok=False)
 
         except queue.Empty:
             pass
@@ -336,48 +353,49 @@ class AudiobookApp(ctk.CTk):
 
             # Прогресс-колбэк — кладёт сообщения в queue.Queue, а НЕ вызывает tkinter!
             def progress_callback(status: str, progress: float, **details):
-                msg = ("progress", status, progress)
-                if details:
-                    msg = msg + (
-                        details.get("current_text"),
-                        details.get("voice"),
-                        details.get("engine"),
-                        details.get("segment_index"),
-                        details.get("segment_total"),
-                    )
-                self._msg_queue.put(msg)
+                self._msg_queue.put((
+                    "progress",
+                    status,
+                    progress,
+                    details.get("current_text"),
+                    details.get("voice"),
+                    details.get("engine"),
+                    details.get("segment_index"),
+                    details.get("segment_total"),
+                    details.get("stage"),
+                    details.get("scope_line"),
+                ))
 
-            # Детальный колбэк для синтеза — передаёт текст, голос, движок
+            # Детальный колбэк оставляем для совместимости бэкендов;
+            # основной UI-прогресс по сегментам идёт через progress_callback из pipeline.
             def detail_callback(
                 completed: int, total: int,
                 text_preview: str, voice: str, backend_name: str,
             ):
-                progress = 0.2 + (completed / total) * 0.2  # прогресс внутри шага синтеза
-                self._msg_queue.put((
-                    "progress",
-                    f"Синтез речи... ({completed}/{total})",
-                    progress,
-                    text_preview[:120],
-                    voice,
-                    backend_name,
-                    completed,
-                    total,
-                ))
+                return
 
             await self._pipeline.run(
                 progress_callback=progress_callback,
                 detail_callback=detail_callback,
             )
 
-            # Успешное завершение — тоже через очередь!
+            # Успешное завершение (в т.ч. частичный результат после отмены)
             self._msg_queue.put(("success", "✅ Аудиокнига создана!"))
+
+        except SynthesisCancelled as e:
+            logger.info("Создание отменено пользователем: %s", e)
+            self._msg_queue.put(("canceled", str(e) or "Создание аудиокниги отменено"))
 
         except Exception as e:
             err_msg = str(e)
-            logger.error(
-                "Ошибка создания аудиокниги: %s\n%s", err_msg, traceback.format_exc()
-            )
-            self._msg_queue.put(("error", err_msg))
+            if "отменен" in err_msg.lower():
+                logger.info("Создание отменено: %s", err_msg)
+                self._msg_queue.put(("canceled", err_msg))
+            else:
+                logger.error(
+                    "Ошибка создания аудиокниги: %s\n%s", err_msg, traceback.format_exc()
+                )
+                self._msg_queue.put(("error", err_msg))
 
     def _on_pause(self):
         """Обработчик паузы."""
@@ -392,10 +410,13 @@ class AudiobookApp(ctk.CTk):
             logger.info("Pipeline возобновлён")
 
     def _on_cancel(self):
-        """Обработчик отмены."""
+        """Отмена: флаг + дождаться конца текущей главы и частичной склейки."""
+        self._user_canceled = True
         if self._pipeline:
             self._pipeline.cancel()
-            logger.info("Pipeline отменён")
+            logger.info("Pipeline: запрошена отмена (после текущей главы)")
+        if self._progress_page:
+            self._progress_page.set_canceling()
 
     def on_closing(self):
         """Обработчик закрытия окна."""

--- a/src/ui/pages/__init__.py
+++ b/src/ui/pages/__init__.py
@@ -5,6 +5,7 @@ from .page_file import PageFile
 from .page_scope import PageScope
 from .page_comments import PageComments
 from .page_launch import PageLaunch
+from .page_create import PageCreate
 
 __all__ = [
     "PageLanguage",
@@ -14,4 +15,5 @@ __all__ = [
     "PageScope",
     "PageComments",
     "PageLaunch",
+    "PageCreate",
 ]

--- a/src/ui/pages/page_create.py
+++ b/src/ui/pages/page_create.py
@@ -1,0 +1,303 @@
+"""
+Шаг 8: Создание аудиокниги — прогресс внутри визарда (не модальное окно).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import tkinter
+from typing import Callable, Optional
+
+import customtkinter as ctk
+
+from src.config.settings import Settings
+from src.utils.scope_display import (
+    STAGE_PREPARE,
+    STAGE_SYNTH,
+    STAGE_LABELS,
+)
+
+logger = logging.getLogger(__name__)
+
+CREATE_TEXTS = {
+    "ru": {
+        "title": "Создание аудиокниги",
+        "pause": "⏸ Пауза",
+        "resume": "▶ Продолжить",
+        "cancel": "✕ Отмена",
+    },
+    "en": {
+        "title": "Creating audiobook",
+        "pause": "⏸ Pause",
+        "resume": "▶ Resume",
+        "cancel": "✕ Cancel",
+    },
+    "ja": {
+        "title": "オーディオブック作成",
+        "pause": "⏸ 一時停止",
+        "resume": "▶ 再開",
+        "cancel": "✕ キャンセル",
+    },
+    "zh": {
+        "title": "正在创建有声书",
+        "pause": "⏸ 暂停",
+        "resume": "▶ 继续",
+        "cancel": "✕ 取消",
+    },
+}
+
+
+class PageCreate(ctk.CTkFrame):
+    """Встроенная страница прогресса создания (шаг визарда)."""
+
+    def __init__(
+        self,
+        parent: ctk.CTkFrame,
+        settings: Settings,
+        on_complete: Optional[Callable] = None,
+    ):
+        super().__init__(parent)
+        self.settings = settings
+        self.on_complete = on_complete  # вызывается при показе — старт pipeline
+        self._start_time = time.time()
+        # Скрытый таймер синтеза сегментов (для ETA «Осталось»)
+        self._synth_start_time: Optional[float] = None
+        self._last_remaining_txt: str = ""
+        self._paused = False
+        self._finished = False
+        self._pause_callback: Optional[Callable] = None
+        self._resume_callback: Optional[Callable] = None
+        self._cancel_callback: Optional[Callable] = None
+        self._nav_restore_callback: Optional[Callable] = None
+
+        self._create_widgets()
+        # Автозапуск после отрисовки
+        self.after(50, self._auto_start)
+
+    def _t(self) -> dict:
+        return CREATE_TEXTS.get(self.settings.ui_lang, CREATE_TEXTS["ru"])
+
+    def _create_widgets(self):
+        t = self._t()
+        main = ctk.CTkFrame(self)
+        main.pack(fill="both", expand=True, padx=20, pady=20)
+
+        self.title_label = ctk.CTkLabel(
+            main, text=t["title"], font=ctk.CTkFont(size=18, weight="bold"),
+        )
+        self.title_label.pack(pady=(0, 10))
+
+        self.stage_label = ctk.CTkLabel(
+            main,
+            text=STAGE_LABELS[STAGE_PREPARE],
+            font=ctk.CTkFont(size=15, weight="bold"),
+        )
+        self.stage_label.pack(pady=(0, 6))
+
+        self.scope_label = ctk.CTkLabel(
+            main, text="", font=ctk.CTkFont(size=12), text_color="gray", wraplength=520,
+        )
+        self.scope_label.pack(pady=(0, 8))
+
+        self.status_label = ctk.CTkLabel(
+            main, text="Подготовка…", font=ctk.CTkFont(size=12), wraplength=520,
+        )
+        self.status_label.pack(pady=(0, 10))
+
+        self.progress_bar = ctk.CTkProgressBar(main, width=440)
+        self.progress_bar.pack(pady=(0, 8))
+        self.progress_bar.set(0.0)
+
+        self.time_label = ctk.CTkLabel(
+            main, text="", font=ctk.CTkFont(size=12), text_color="gray",
+        )
+        self.time_label.pack(pady=(0, 10))
+
+        self.detail_frame = ctk.CTkFrame(main)
+        self.text_preview_label = ctk.CTkLabel(
+            self.detail_frame, text="", font=ctk.CTkFont(size=11),
+            wraplength=500, justify="left", anchor="w", text_color="gray",
+        )
+        self.text_preview_label.pack(fill="x", padx=10, pady=(5, 2))
+        self.voice_engine_label = ctk.CTkLabel(
+            self.detail_frame, text="", font=ctk.CTkFont(size=11),
+            anchor="w", text_color="gray",
+        )
+        self.voice_engine_label.pack(fill="x", padx=10, pady=(0, 5))
+
+        # Пауза / Отмена живут в нижней панели визарда
+        self.pause_btn = None
+        self.cancel_btn = None
+
+    def _auto_start(self):
+        if self.on_complete and not self._finished:
+            self.on_complete()
+
+    def set_pause_callback(self, cb: Callable):
+        self._pause_callback = cb
+
+    def set_resume_callback(self, cb: Callable):
+        self._resume_callback = cb
+
+    def set_cancel_callback(self, cb: Callable):
+        self._cancel_callback = cb
+
+    def set_nav_restore_callback(self, cb: Callable):
+        """Включить стандартную навигацию «Назад» после завершения/отмены."""
+        self._nav_restore_callback = cb
+
+    def bind_nav_controls(self, pause_btn, cancel_btn):
+        """Привязать кнопки нижней панели визарда."""
+        self.pause_btn = pause_btn
+        self.cancel_btn = cancel_btn
+        pause_btn.configure(command=self._on_pause)
+        cancel_btn.configure(command=self._on_cancel)
+
+    def update_progress(
+        self,
+        status: str,
+        progress: float,
+        current_text: Optional[str] = None,
+        voice: Optional[str] = None,
+        engine: Optional[str] = None,
+        segment_index: Optional[int] = None,
+        segment_total: Optional[int] = None,
+        stage: Optional[str] = None,
+        scope_line: Optional[str] = None,
+    ):
+        self.after(
+            0, self._do_update_progress, status, progress,
+            current_text, voice, engine, segment_index, segment_total,
+            stage, scope_line,
+        )
+
+    def _do_update_progress(
+        self,
+        status: str,
+        progress: float,
+        current_text: Optional[str] = None,
+        voice: Optional[str] = None,
+        engine: Optional[str] = None,
+        segment_index: Optional[int] = None,
+        segment_total: Optional[int] = None,
+        stage: Optional[str] = None,
+        scope_line: Optional[str] = None,
+    ):
+        try:
+            if stage:
+                self.stage_label.configure(text=STAGE_LABELS.get(stage, stage))
+            if scope_line is not None:
+                self.scope_label.configure(text=scope_line)
+            self.status_label.configure(text=status)
+            self.progress_bar.set(max(0.0, min(1.0, progress)))
+
+            # Старт скрытого таймера — с начала синтеза сегментов
+            if stage == STAGE_SYNTH and self._synth_start_time is None:
+                self._synth_start_time = time.time()
+
+            elapsed = time.time() - self._start_time
+            remaining_txt = ""
+            # ETA: после каждого завершённого сегмента
+            # (elapsed_synth / done) * remaining
+            # Обновляем только по post-complete апдейтам (без current_text),
+            # где segment_index = число завершённых сегментов.
+            if (
+                self._synth_start_time is not None
+                and stage == STAGE_SYNTH
+                and current_text is None
+                and segment_index is not None
+                and segment_total is not None
+                and segment_index > 0
+            ):
+                synth_elapsed = time.time() - self._synth_start_time
+                left = max(0, segment_total - segment_index)
+                if left == 0:
+                    remaining_txt = f" | Осталось: {self._fmt(0)}"
+                else:
+                    remaining = (synth_elapsed / segment_index) * left
+                    remaining_txt = f" | Осталось: {self._fmt(remaining)}"
+            elif self._last_remaining_txt and stage == STAGE_SYNTH:
+                # Пока идёт текущий сегмент — показываем последнюю оценку
+                remaining_txt = self._last_remaining_txt
+
+            if remaining_txt:
+                self._last_remaining_txt = remaining_txt
+            elif stage and stage != STAGE_SYNTH:
+                self._last_remaining_txt = ""
+
+            self.time_label.configure(text=f"Прошло: {self._fmt(elapsed)}{remaining_txt}")
+
+            if current_text is not None:
+                self.detail_frame.pack(fill="x", padx=10, pady=(0, 10))
+                preview = current_text[:120]
+                self.text_preview_label.configure(
+                    text=f"📖 {preview}{'…' if len(current_text) > 120 else ''}"
+                )
+                eng_map = {
+                    "edge": "Edge TTS", "piper": "Piper",
+                    "silero": "Silero", "supertonic": "Supertonic",
+                }
+                parts = []
+                if engine:
+                    parts.append(f"⚙ {eng_map.get(engine, engine)}")
+                if voice:
+                    short = voice.split("-", 1)[-1] if "-" in voice else voice
+                    parts.append(f"🗣 {short}")
+                if segment_index is not None and segment_total is not None:
+                    parts.append(f"#{segment_index}/{segment_total}")
+                self.voice_engine_label.configure(text=" | ".join(parts))
+            else:
+                self.detail_frame.pack_forget()
+        except (AttributeError, tkinter.TclError):
+            pass
+
+    def show_finished(self, ok: bool = True):
+        """После завершения/отмены: убрать Pause/Cancel, вернуть «Назад» визарда."""
+        self._finished = True
+        if self._nav_restore_callback:
+            self._nav_restore_callback()
+
+    def set_canceling(self):
+        """После нажатия «Отмена»: кнопка неактивна, ждём конец главы и склейку."""
+        if self.cancel_btn is not None:
+            self.cancel_btn.configure(state="disabled")
+        # Статус подскажет, что процесс ещё завершает текущую главу
+        try:
+            self.status_label.configure(text="Отмена после текущей главы…")
+        except (AttributeError, tkinter.TclError):
+            pass
+
+    def _on_pause(self):
+        t = self._t()
+        if self._paused:
+            self._paused = False
+            if self.pause_btn is not None:
+                self.pause_btn.configure(text=t["pause"])
+            if self._resume_callback:
+                self._resume_callback()
+        else:
+            self._paused = True
+            if self.pause_btn is not None:
+                self.pause_btn.configure(text=t["resume"])
+            if self._pause_callback:
+                self._pause_callback()
+
+    def _on_cancel(self):
+        if self._cancel_callback:
+            self._cancel_callback()
+
+    def get_data(self) -> dict:
+        return {}
+
+    def validate(self) -> bool:
+        return True
+
+    @staticmethod
+    def _fmt(seconds: float) -> str:
+        hours = int(seconds // 3600)
+        minutes = int((seconds % 3600) // 60)
+        secs = int(seconds % 60)
+        if hours > 0:
+            return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+        return f"{minutes:02d}:{secs:02d}"

--- a/src/ui/pages/page_create.py
+++ b/src/ui/pages/page_create.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 import time
 import tkinter
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 import customtkinter as ctk
@@ -15,6 +16,9 @@ from src.config.settings import Settings
 from src.utils.scope_display import (
     STAGE_PREPARE,
     STAGE_SYNTH,
+    STAGE_CHAPTER_MERGE,
+    STAGE_BOOK_MERGE,
+    STAGE_DONE,
     STAGE_LABELS,
 )
 
@@ -23,29 +27,57 @@ logger = logging.getLogger(__name__)
 CREATE_TEXTS = {
     "ru": {
         "title": "Создание аудиокниги",
+        "synth_block": "Синтез речи по главам",
+        "merge_block": "Склеивание по главам",
+        "waiting": "Ожидание…",
         "pause": "⏸ Пауза",
         "resume": "▶ Продолжить",
         "cancel": "✕ Отмена",
     },
     "en": {
         "title": "Creating audiobook",
+        "synth_block": "Speech synthesis by chapters",
+        "merge_block": "Merging by chapters",
+        "waiting": "Waiting…",
         "pause": "⏸ Pause",
         "resume": "▶ Resume",
         "cancel": "✕ Cancel",
     },
     "ja": {
         "title": "オーディオブック作成",
+        "synth_block": "章ごとの音声合成",
+        "merge_block": "章ごとの結合",
+        "waiting": "待機中…",
         "pause": "⏸ 一時停止",
         "resume": "▶ 再開",
         "cancel": "✕ キャンセル",
     },
     "zh": {
         "title": "正在创建有声书",
+        "synth_block": "按章语音合成",
+        "merge_block": "按章合并",
+        "waiting": "等待中…",
         "pause": "⏸ 暂停",
         "resume": "▶ 继续",
         "cancel": "✕ 取消",
     },
 }
+
+
+@dataclass
+class _StageBlock:
+    """Виджеты одного этапа (синтез / склейка)."""
+    frame: ctk.CTkFrame
+    title_label: ctk.CTkLabel
+    scope_label: ctk.CTkLabel
+    status_label: ctk.CTkLabel
+    progress_bar: ctk.CTkProgressBar
+    time_label: ctk.CTkLabel
+    detail_frame: Optional[ctk.CTkFrame] = None
+    text_preview_label: Optional[ctk.CTkLabel] = None
+    voice_engine_label: Optional[ctk.CTkLabel] = None
+    eta_start_time: Optional[float] = None
+    last_remaining_txt: str = ""
 
 
 class PageCreate(ctk.CTkFrame):
@@ -61,15 +93,13 @@ class PageCreate(ctk.CTkFrame):
         self.settings = settings
         self.on_complete = on_complete  # вызывается при показе — старт pipeline
         self._start_time = time.time()
-        # Скрытый таймер синтеза сегментов (для ETA «Осталось»)
-        self._synth_start_time: Optional[float] = None
-        self._last_remaining_txt: str = ""
         self._paused = False
         self._finished = False
         self._pause_callback: Optional[Callable] = None
         self._resume_callback: Optional[Callable] = None
         self._cancel_callback: Optional[Callable] = None
         self._nav_restore_callback: Optional[Callable] = None
+        self._active_block: Optional[_StageBlock] = None
 
         self._create_widgets()
         # Автозапуск после отрисовки
@@ -78,53 +108,85 @@ class PageCreate(ctk.CTkFrame):
     def _t(self) -> dict:
         return CREATE_TEXTS.get(self.settings.ui_lang, CREATE_TEXTS["ru"])
 
+    def _make_stage_block(
+        self,
+        parent: ctk.CTkFrame,
+        title: str,
+        *,
+        with_detail: bool = False,
+    ) -> _StageBlock:
+        frame = ctk.CTkFrame(parent)
+        frame.pack(fill="x", padx=20, pady=(0, 12))
+
+        title_label = ctk.CTkLabel(
+            frame, text=title, font=ctk.CTkFont(size=15, weight="bold"),
+        )
+        title_label.pack(pady=(12, 6))
+
+        scope_label = ctk.CTkLabel(
+            frame, text="", font=ctk.CTkFont(size=12), text_color="gray", wraplength=520,
+        )
+        scope_label.pack(pady=(0, 6))
+
+        status_label = ctk.CTkLabel(
+            frame, text=self._t()["waiting"], font=ctk.CTkFont(size=12), wraplength=520,
+        )
+        status_label.pack(pady=(0, 8))
+
+        progress_bar = ctk.CTkProgressBar(frame, width=440)
+        progress_bar.pack(pady=(0, 8))
+        progress_bar.set(0.0)
+
+        time_label = ctk.CTkLabel(
+            frame, text="", font=ctk.CTkFont(size=12), text_color="gray",
+        )
+        time_label.pack(pady=(0, 10))
+
+        detail_frame = None
+        text_preview_label = None
+        voice_engine_label = None
+        if with_detail:
+            detail_frame = ctk.CTkFrame(frame)
+            text_preview_label = ctk.CTkLabel(
+                detail_frame, text="", font=ctk.CTkFont(size=11),
+                wraplength=500, justify="left", anchor="w", text_color="gray",
+            )
+            text_preview_label.pack(fill="x", padx=10, pady=(5, 2))
+            voice_engine_label = ctk.CTkLabel(
+                detail_frame, text="", font=ctk.CTkFont(size=11),
+                anchor="w", text_color="gray",
+            )
+            voice_engine_label.pack(fill="x", padx=10, pady=(0, 5))
+
+        return _StageBlock(
+            frame=frame,
+            title_label=title_label,
+            scope_label=scope_label,
+            status_label=status_label,
+            progress_bar=progress_bar,
+            time_label=time_label,
+            detail_frame=detail_frame,
+            text_preview_label=text_preview_label,
+            voice_engine_label=voice_engine_label,
+        )
+
     def _create_widgets(self):
         t = self._t()
-        main = ctk.CTkFrame(self)
-        main.pack(fill="both", expand=True, padx=20, pady=20)
 
+        # Заголовок страницы — как на других шагах визарда
         self.title_label = ctk.CTkLabel(
-            main, text=t["title"], font=ctk.CTkFont(size=18, weight="bold"),
+            self, text=t["title"], font=ctk.CTkFont(size=20, weight="bold"),
         )
-        self.title_label.pack(pady=(0, 10))
+        self.title_label.pack(pady=(30, 16))
 
-        self.stage_label = ctk.CTkLabel(
-            main,
-            text=STAGE_LABELS[STAGE_PREPARE],
-            font=ctk.CTkFont(size=15, weight="bold"),
+        self.synth_block = self._make_stage_block(
+            self, t["synth_block"], with_detail=True,
         )
-        self.stage_label.pack(pady=(0, 6))
-
-        self.scope_label = ctk.CTkLabel(
-            main, text="", font=ctk.CTkFont(size=12), text_color="gray", wraplength=520,
+        self.merge_block = self._make_stage_block(
+            self, t["merge_block"], with_detail=False,
         )
-        self.scope_label.pack(pady=(0, 8))
-
-        self.status_label = ctk.CTkLabel(
-            main, text="Подготовка…", font=ctk.CTkFont(size=12), wraplength=520,
-        )
-        self.status_label.pack(pady=(0, 10))
-
-        self.progress_bar = ctk.CTkProgressBar(main, width=440)
-        self.progress_bar.pack(pady=(0, 8))
-        self.progress_bar.set(0.0)
-
-        self.time_label = ctk.CTkLabel(
-            main, text="", font=ctk.CTkFont(size=12), text_color="gray",
-        )
-        self.time_label.pack(pady=(0, 10))
-
-        self.detail_frame = ctk.CTkFrame(main)
-        self.text_preview_label = ctk.CTkLabel(
-            self.detail_frame, text="", font=ctk.CTkFont(size=11),
-            wraplength=500, justify="left", anchor="w", text_color="gray",
-        )
-        self.text_preview_label.pack(fill="x", padx=10, pady=(5, 2))
-        self.voice_engine_label = ctk.CTkLabel(
-            self.detail_frame, text="", font=ctk.CTkFont(size=11),
-            anchor="w", text_color="gray",
-        )
-        self.voice_engine_label.pack(fill="x", padx=10, pady=(0, 5))
+        self._active_block = self.synth_block
+        self.synth_block.status_label.configure(text=STAGE_LABELS[STAGE_PREPARE])
 
         # Пауза / Отмена живут в нижней панели визарда
         self.pause_btn = None
@@ -153,6 +215,29 @@ class PageCreate(ctk.CTkFrame):
         self.cancel_btn = cancel_btn
         pause_btn.configure(command=self._on_pause)
         cancel_btn.configure(command=self._on_cancel)
+
+    def _block_for_stage(self, stage: Optional[str]) -> _StageBlock:
+        if stage in (STAGE_CHAPTER_MERGE, STAGE_BOOK_MERGE, STAGE_DONE):
+            return self.merge_block
+        return self.synth_block
+
+    def _stage_progress(self, stage: Optional[str], overall: float) -> float:
+        """Локальный прогресс 0..1 внутри блока этапа."""
+        w_prep = 0.08
+        w_synth = 0.72
+        w_ch = 0.15
+        w_book = 0.05
+        if stage in (None, STAGE_PREPARE):
+            return max(0.0, min(1.0, overall / max(w_prep, 1e-6)))
+        if stage == STAGE_SYNTH:
+            return max(0.0, min(1.0, (overall - w_prep) / max(w_synth, 1e-6)))
+        if stage == STAGE_CHAPTER_MERGE:
+            return max(0.0, min(1.0, (overall - w_prep - w_synth) / max(w_ch, 1e-6)))
+        if stage == STAGE_BOOK_MERGE:
+            return max(0.0, min(1.0, (overall - w_prep - w_synth - w_ch) / max(w_book, 1e-6)))
+        if stage == STAGE_DONE:
+            return 1.0
+        return max(0.0, min(1.0, overall))
 
     def update_progress(
         self,
@@ -185,70 +270,92 @@ class PageCreate(ctk.CTkFrame):
         scope_line: Optional[str] = None,
     ):
         try:
-            if stage:
-                self.stage_label.configure(text=STAGE_LABELS.get(stage, stage))
-            if scope_line is not None:
-                self.scope_label.configure(text=scope_line)
-            self.status_label.configure(text=status)
-            self.progress_bar.set(max(0.0, min(1.0, progress)))
+            block = self._block_for_stage(stage)
+            self._active_block = block
 
-            # Старт скрытого таймера — с начала синтеза сегментов
-            if stage == STAGE_SYNTH and self._synth_start_time is None:
-                self._synth_start_time = time.time()
-
-            elapsed = time.time() - self._start_time
-            remaining_txt = ""
-            # ETA: после каждого завершённого сегмента
-            # (elapsed_synth / done) * remaining
-            # Обновляем только по post-complete апдейтам (без current_text),
-            # где segment_index = число завершённых сегментов.
+            # При переходе на склейку — синтез на 100%
             if (
-                self._synth_start_time is not None
-                and stage == STAGE_SYNTH
+                block is self.merge_block
+                and stage in (STAGE_CHAPTER_MERGE, STAGE_BOOK_MERGE, STAGE_DONE)
+            ):
+                self.synth_block.progress_bar.set(1.0)
+
+            if stage == STAGE_BOOK_MERGE:
+                block.title_label.configure(text=STAGE_LABELS[STAGE_BOOK_MERGE])
+            elif stage == STAGE_DONE:
+                block.title_label.configure(text=STAGE_LABELS[STAGE_DONE])
+            elif block is self.merge_block and stage == STAGE_CHAPTER_MERGE:
+                block.title_label.configure(text=self._t()["merge_block"])
+
+            if scope_line is not None:
+                block.scope_label.configure(text=scope_line)
+            block.status_label.configure(text=status)
+            block.progress_bar.set(self._stage_progress(stage, progress))
+
+            # ETA: свой таймер на блок, формула после каждого завершённого сегмента
+            eta_ok = stage in (STAGE_SYNTH, STAGE_CHAPTER_MERGE)
+            if eta_ok:
+                if block.eta_start_time is None:
+                    block.eta_start_time = time.time()
+                    block.last_remaining_txt = ""
+            elif stage in (STAGE_BOOK_MERGE, STAGE_DONE, STAGE_PREPARE):
+                # для book_merge оставляем elapsed блока склейки без пересчёта сегментов
+                pass
+
+            remaining_txt = ""
+            if (
+                eta_ok
+                and block.eta_start_time is not None
                 and current_text is None
                 and segment_index is not None
                 and segment_total is not None
                 and segment_index > 0
             ):
-                synth_elapsed = time.time() - self._synth_start_time
+                stage_elapsed = time.time() - block.eta_start_time
                 left = max(0, segment_total - segment_index)
                 if left == 0:
                     remaining_txt = f" | Осталось: {self._fmt(0)}"
                 else:
-                    remaining = (synth_elapsed / segment_index) * left
+                    remaining = (stage_elapsed / segment_index) * left
                     remaining_txt = f" | Осталось: {self._fmt(remaining)}"
-            elif self._last_remaining_txt and stage == STAGE_SYNTH:
-                # Пока идёт текущий сегмент — показываем последнюю оценку
-                remaining_txt = self._last_remaining_txt
+            elif eta_ok and block.last_remaining_txt:
+                remaining_txt = block.last_remaining_txt
 
             if remaining_txt:
-                self._last_remaining_txt = remaining_txt
-            elif stage and stage != STAGE_SYNTH:
-                self._last_remaining_txt = ""
+                block.last_remaining_txt = remaining_txt
 
-            self.time_label.configure(text=f"Прошло: {self._fmt(elapsed)}{remaining_txt}")
-
-            if current_text is not None:
-                self.detail_frame.pack(fill="x", padx=10, pady=(0, 10))
-                preview = current_text[:120]
-                self.text_preview_label.configure(
-                    text=f"📖 {preview}{'…' if len(current_text) > 120 else ''}"
+            if block.eta_start_time is not None:
+                block_elapsed = time.time() - block.eta_start_time
+                block.time_label.configure(
+                    text=f"Прошло: {self._fmt(block_elapsed)}{remaining_txt}"
                 )
-                eng_map = {
-                    "edge": "Edge TTS", "piper": "Piper",
-                    "silero": "Silero", "supertonic": "Supertonic",
-                }
-                parts = []
-                if engine:
-                    parts.append(f"⚙ {eng_map.get(engine, engine)}")
-                if voice:
-                    short = voice.split("-", 1)[-1] if "-" in voice else voice
-                    parts.append(f"🗣 {short}")
-                if segment_index is not None and segment_total is not None:
-                    parts.append(f"#{segment_index}/{segment_total}")
-                self.voice_engine_label.configure(text=" | ".join(parts))
-            else:
-                self.detail_frame.pack_forget()
+            elif progress > 0:
+                # подготовка / финал без сегментного таймера — общее время страницы
+                elapsed = time.time() - self._start_time
+                block.time_label.configure(text=f"Прошло: {self._fmt(elapsed)}")
+
+            if block.detail_frame is not None:
+                if current_text is not None:
+                    block.detail_frame.pack(fill="x", padx=10, pady=(0, 10))
+                    preview = current_text[:120]
+                    block.text_preview_label.configure(
+                        text=f"📖 {preview}{'…' if len(current_text) > 120 else ''}"
+                    )
+                    eng_map = {
+                        "edge": "Edge TTS", "piper": "Piper",
+                        "silero": "Silero", "supertonic": "Supertonic",
+                    }
+                    parts = []
+                    if engine:
+                        parts.append(f"⚙ {eng_map.get(engine, engine)}")
+                    if voice:
+                        short = voice.split("-", 1)[-1] if "-" in voice else voice
+                        parts.append(f"🗣 {short}")
+                    if segment_index is not None and segment_total is not None:
+                        parts.append(f"#{segment_index}/{segment_total}")
+                    block.voice_engine_label.configure(text=" | ".join(parts))
+                else:
+                    block.detail_frame.pack_forget()
         except (AttributeError, tkinter.TclError):
             pass
 
@@ -262,9 +369,9 @@ class PageCreate(ctk.CTkFrame):
         """После нажатия «Отмена»: кнопка неактивна, ждём конец главы и склейку."""
         if self.cancel_btn is not None:
             self.cancel_btn.configure(state="disabled")
-        # Статус подскажет, что процесс ещё завершает текущую главу
         try:
-            self.status_label.configure(text="Отмена после текущей главы…")
+            block = self._active_block or self.synth_block
+            block.status_label.configure(text="Отмена после текущей главы…")
         except (AttributeError, tkinter.TclError):
             pass
 

--- a/src/ui/pages/page_launch.py
+++ b/src/ui/pages/page_launch.py
@@ -11,7 +11,9 @@ from typing import Callable, Optional
 import customtkinter as ctk
 
 from src.config.settings import Settings
+from src.core.fb2_parser import FB2Parser
 from src.core.tts_manager import resolve_voice
+from src.utils.scope_display import format_scope
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,9 @@ LAUNCH_TEXTS = {
         "freq_label": "Комментарии",
         "freq_format": "каждые {} предложений",
         "freq_off": "Отключены",
+        "scope_label": "Объём озвучки",
+        "total_chapters_label": "Всего глав в файле",
+        "total_chapters_unknown": "—",
         "voice_main_label": "Голос текста",
         "voice_comment_label": "Голос комментатора",
         "output_label": "Путь сохранения",
@@ -43,6 +48,9 @@ LAUNCH_TEXTS = {
         "freq_label": "Comments",
         "freq_format": "every {} sentences",
         "freq_off": "Disabled",
+        "scope_label": "Narration scope",
+        "total_chapters_label": "Total chapters in file",
+        "total_chapters_unknown": "—",
         "voice_main_label": "Text voice",
         "voice_comment_label": "Comment voice",
         "output_label": "Output path",
@@ -60,6 +68,9 @@ LAUNCH_TEXTS = {
         "freq_label": "コメント",
         "freq_format": "{}文ごと",
         "freq_off": "無効",
+        "scope_label": "ナレーション範囲",
+        "total_chapters_label": "ファイル内の総章数",
+        "total_chapters_unknown": "—",
         "voice_main_label": "テキストの声",
         "voice_comment_label": "コメントの声",
         "output_label": "出力先",
@@ -76,6 +87,9 @@ LAUNCH_TEXTS = {
         "freq_label": "评论",
         "freq_format": "每{}句",
         "freq_off": "已禁用",
+        "scope_label": "朗读范围",
+        "total_chapters_label": "文件中总章节数",
+        "total_chapters_unknown": "—",
         "voice_main_label": "正文语音",
         "voice_comment_label": "评论语音",
         "output_label": "输出路径",
@@ -106,6 +120,7 @@ class PageLaunch(ctk.CTkFrame):
         super().__init__(parent)
         self.settings = settings
         self.on_complete = on_complete
+        self._total_chapters: Optional[int] = self._count_chapters()
 
         self._create_widgets()
 
@@ -147,10 +162,18 @@ class PageLaunch(ctk.CTkFrame):
             self.settings.tts_backend, self.settings.tts_backend
         )
 
+        total_display = (
+            str(self._total_chapters)
+            if self._total_chapters is not None
+            else t["total_chapters_unknown"]
+        )
+
         items = [
             (t["lang_label"], self._lang_display(self.settings.book_lang)),
             (t["provider_label"], self.settings.ai_provider.capitalize()),
             (t["freq_label"], self._comment_summary()),
+            (t["scope_label"], self._scope_summary()),
+            (t["total_chapters_label"], total_display),
             (t["voice_main_label"], resolve_voice(
                 self.settings.tts_backend, self.settings.book_lang, self.settings.main_gender,
             )),
@@ -181,19 +204,6 @@ class PageLaunch(ctk.CTkFrame):
                 anchor="w",
             ).pack(side="left", padx=5, pady=2)
 
-        # Кнопка запуска
-        self.launch_btn = ctk.CTkButton(
-            self,
-            text=self._get_launch_text(),
-            font=ctk.CTkFont(size=16, weight="bold"),
-            command=self._on_launch,
-            height=50,
-            width=400,
-            fg_color="green",
-            hover_color="darkgreen",
-        )
-        self.launch_btn.pack(pady=30)
-
         # Предупреждение
         warning = ctk.CTkLabel(
             self,
@@ -202,7 +212,7 @@ class PageLaunch(ctk.CTkFrame):
             text_color="orange",
             justify="center",
         )
-        warning.pack(pady=(0, 10))
+        warning.pack(pady=(20, 10))
 
     def _lang_display(self, code: str) -> str:
         """Конвертация кода языка в отображаемое название."""
@@ -224,21 +234,29 @@ class PageLaunch(ctk.CTkFrame):
         t = LAUNCH_TEXTS.get(lang, LAUNCH_TEXTS["ru"])
         return t["freq_format"].format(self.settings.comment_frequency)
 
-    def _get_launch_text(self) -> str:
-        """Получение текста кнопки запуска."""
-        lang = self.settings.ui_lang
-        t = LAUNCH_TEXTS.get(lang, LAUNCH_TEXTS["ru"])
-        book_path = getattr(self.settings, "book_path", "")
-        if book_path:
-            name = Path(str(book_path)).stem
-            return f'{t["launch_default"]} "{name}"'
-        return t["launch_default"]
+    def _count_chapters(self) -> Optional[int]:
+        """Число глав в выбранном FB2 (для сводки)."""
+        book_path = getattr(self.settings, "book_path", "") or ""
+        if not book_path:
+            return None
+        path = Path(book_path)
+        if not path.exists():
+            return None
+        try:
+            book = FB2Parser().parse(path)
+            return len(book.chapters)
+        except Exception as exc:
+            logger.warning("Не удалось посчитать главы для сводки: %s", exc)
+            return None
 
-    def _on_launch(self):
-        """Обработчик нажатия кнопки запуска."""
-        logger.info("Запуск создания аудиокниги")
-        if self.on_complete:
-            self.on_complete()
+    def _scope_summary(self) -> str:
+        """Человекочитаемый объём озвучки по chapter_start/chapter_end."""
+        return format_scope(
+            int(getattr(self.settings, "chapter_start", 0) or 0),
+            int(getattr(self.settings, "chapter_end", 0) or 0),
+            self._total_chapters,
+            self.settings.ui_lang,
+        )
 
     def get_data(self) -> dict:
         """Сбор данных со страницы."""

--- a/src/ui/progress_window.py
+++ b/src/ui/progress_window.py
@@ -1,6 +1,6 @@
 """
 Окно прогресса создания аудиокниги.
-Отображает полосу прогресса, текущую главу, процент выполнения и оценку времени.
+Отображает этап, объём/текущую главу, полосу прогресса и оценку времени.
 """
 
 from __future__ import annotations
@@ -13,6 +13,15 @@ from typing import Callable, Optional
 
 import customtkinter as ctk
 
+from src.utils.scope_display import (
+    STAGE_PREPARE,
+    STAGE_SYNTH,
+    STAGE_CHAPTER_MERGE,
+    STAGE_BOOK_MERGE,
+    STAGE_DONE,
+    STAGE_LABELS,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -20,10 +29,9 @@ class ProgressWindow(ctk.CTkToplevel):
     """Окно прогресса создания аудиокниги.
 
     Отображает:
-    - Полосу прогресса
-    - Текущий статус
-    - Процент выполнения
-    - Оценку оставшегося времени
+    - Текущий этап (синтез / склейка глав / склейка книги)
+    - Текущую главу, режим объёма и всего глав
+    - Полосу прогресса и оценку времени
     - Кнопки паузы и отмены
     """
 
@@ -34,7 +42,7 @@ class ProgressWindow(ctk.CTkToplevel):
     ):
         super().__init__(parent)
         self.title(title)
-        self.geometry("500x300")
+        self.geometry("520x340")
         self.resizable(False, False)
 
         # Центрируем относительно родителя
@@ -75,29 +83,39 @@ class ProgressWindow(ctk.CTkToplevel):
             text="Создание аудиокниги",
             font=ctk.CTkFont(size=18, weight="bold"),
         )
-        self.title_label.pack(pady=(0, 15))
+        self.title_label.pack(pady=(0, 10))
 
-        # Статус
+        # Этап вместо процента
+        self.stage_label = ctk.CTkLabel(
+            main_frame,
+            text=STAGE_LABELS[STAGE_PREPARE],
+            font=ctk.CTkFont(size=15, weight="bold"),
+        )
+        self.stage_label.pack(pady=(0, 6))
+
+        # Глава / объём / всего
+        self.scope_label = ctk.CTkLabel(
+            main_frame,
+            text="",
+            font=ctk.CTkFont(size=12),
+            text_color="gray",
+            wraplength=470,
+        )
+        self.scope_label.pack(pady=(0, 8))
+
+        # Статус (детали: сегменты и т.п.)
         self.status_label = ctk.CTkLabel(
             main_frame,
             text="Подготовка...",
-            font=ctk.CTkFont(size=13),
-            wraplength=450,
+            font=ctk.CTkFont(size=12),
+            wraplength=470,
         )
         self.status_label.pack(pady=(0, 10))
 
         # Полоса прогресса
-        self.progress_bar = ctk.CTkProgressBar(main_frame, width=400)
-        self.progress_bar.pack(pady=(0, 10))
+        self.progress_bar = ctk.CTkProgressBar(main_frame, width=420)
+        self.progress_bar.pack(pady=(0, 8))
         self.progress_bar.set(0.0)
-
-        # Процент
-        self.percent_label = ctk.CTkLabel(
-            main_frame,
-            text="0%",
-            font=ctk.CTkFont(size=13),
-        )
-        self.percent_label.pack(pady=(0, 5))
 
         # Оценка времени
         self.time_label = ctk.CTkLabel(
@@ -116,7 +134,7 @@ class ProgressWindow(ctk.CTkToplevel):
             self.detail_frame,
             text="",
             font=ctk.CTkFont(size=11),
-            wraplength=450,
+            wraplength=470,
             justify="left",
             anchor="w",
             text_color="gray",
@@ -192,21 +210,36 @@ class ProgressWindow(ctk.CTkToplevel):
         engine: Optional[str] = None,
         segment_index: Optional[int] = None,
         segment_total: Optional[int] = None,
+        stage: Optional[str] = None,
+        scope_line: Optional[str] = None,
     ):
         """Обновление прогресса.
 
         Args:
             status: Текстовый статус.
-            progress: Прогресс от 0.0 до 1.0.
+            progress: Прогресс от 0.0 до 1.0 (для полосы и ETA).
             current_text: Текст текущего синтезируемого сегмента.
             voice: Имя голоса.
             engine: Название TTS-движка.
             segment_index: Номер текущего сегмента.
             segment_total: Всего сегментов.
+            stage: Код этапа (synth / chapter_merge / book_merge …).
+            scope_line: Строка «Глава N · режим · всего глав X».
         """
         # Обновление в главном потоке
-        self.after(0, self._do_update_progress, status, progress,
-                   current_text, voice, engine, segment_index, segment_total)
+        self.after(
+            0,
+            self._do_update_progress,
+            status,
+            progress,
+            current_text,
+            voice,
+            engine,
+            segment_index,
+            segment_total,
+            stage,
+            scope_line,
+        )
 
     def _do_update_progress(
         self,
@@ -217,12 +250,20 @@ class ProgressWindow(ctk.CTkToplevel):
         engine: Optional[str] = None,
         segment_index: Optional[int] = None,
         segment_total: Optional[int] = None,
+        stage: Optional[str] = None,
+        scope_line: Optional[str] = None,
     ):
         """Обновление виджетов прогресса (в главном потоке)."""
         try:
+            if stage:
+                self.stage_label.configure(
+                    text=STAGE_LABELS.get(stage, stage),
+                )
+            if scope_line is not None:
+                self.scope_label.configure(text=scope_line)
+
             self.status_label.configure(text=status)
-            self.progress_bar.set(progress)
-            self.percent_label.configure(text=f"{int(progress * 100)}%")
+            self.progress_bar.set(max(0.0, min(1.0, progress)))
 
             # Оценка времени
             elapsed = time.time() - self._start_time
@@ -233,6 +274,10 @@ class ProgressWindow(ctk.CTkToplevel):
                     self.time_label.configure(
                         text=f"Прошло: {self._format_time(elapsed)} | "
                              f"Осталось: {self._format_time(remaining)}"
+                    )
+                else:
+                    self.time_label.configure(
+                        text=f"Прошло: {self._format_time(elapsed)}"
                     )
             else:
                 self.time_label.configure(
@@ -251,7 +296,12 @@ class ProgressWindow(ctk.CTkToplevel):
 
                 parts = []
                 if engine:
-                    engine_name = {"edge": "Edge TTS", "piper": "Piper (локальный)"}.get(engine, engine)
+                    engine_name = {
+                        "edge": "Edge TTS",
+                        "piper": "Piper (локальный)",
+                        "silero": "Silero TTS",
+                        "supertonic": "Supertonic 3",
+                    }.get(engine, engine)
                     parts.append(f"⚙ {engine_name}")
                 if voice:
                     # Краткое имя голоса (убираем префикс языка)

--- a/src/ui/wizard.py
+++ b/src/ui/wizard.py
@@ -20,16 +20,17 @@ from src.ui.pages import (
     PageScope,
     PageComments,
     PageLaunch,
+    PageCreate,
 )
 
 logger = logging.getLogger(__name__)
 
 # Названия шагов на разных языках
 STEP_NAMES = {
-    "ru": ["Язык", "API", "О нас", "Файл", "Объём", "Комментарии", "Запуск"],
-    "en": ["Language", "API", "About", "File", "Scope", "Comments", "Launch"],
-    "ja": ["言語", "API", "概要", "ファイル", "範囲", "コメント", "開始"],
-    "zh": ["语言", "API", "关于", "文件", "范围", "评论", "启动"],
+    "ru": ["Язык", "API", "О нас", "Файл", "Комментарии", "Объём", "Запуск", "Создание"],
+    "en": ["Language", "API", "About", "File", "Comments", "Scope", "Launch", "Create"],
+    "ja": ["言語", "API", "概要", "ファイル", "コメント", "範囲", "開始", "作成"],
+    "zh": ["语言", "API", "关于", "文件", "评论", "范围", "启动", "创建"],
 }
 
 # Тексты навигационных кнопок
@@ -69,8 +70,8 @@ class WizardController:
         self.step_labels: List[ctk.CTkLabel] = []
         self._create_step_indicator()
 
-        # Контейнер для содержимого страницы
-        self.content_frame = ctk.CTkFrame(parent)
+        # Контейнер для содержимого страницы (с прокруткой, если не помещается)
+        self.content_frame = ctk.CTkScrollableFrame(parent)
         self.content_frame.pack(fill="both", expand=True, padx=5, pady=5)
 
         # Навигационные кнопки
@@ -96,6 +97,21 @@ class WizardController:
         )
         self.next_btn.pack(side="right", padx=10, pady=5)
 
+        # Пауза / Отмена — на шаге «Создание» вместо «Далее»
+        create_t = self._create_nav_texts()
+        self.pause_btn = ctk.CTkButton(
+            self.nav_frame,
+            text=create_t["pause"],
+            width=130,
+        )
+        self.cancel_btn = ctk.CTkButton(
+            self.nav_frame,
+            text=create_t["cancel"],
+            width=130,
+            fg_color="red",
+            hover_color="darkred",
+        )
+
     def _create_step_indicator(self):
         """Создание индикатора шагов вверху мастера."""
         lang = self.settings.ui_lang
@@ -104,7 +120,7 @@ class WizardController:
             label = ctk.CTkLabel(
                 self.steps_frame,
                 text=f"{i + 1}. {name}",
-                font=ctk.CTkFont(size=11),
+                font=ctk.CTkFont(size=10),
             )
             label.pack(side="left", padx=8, pady=5, expand=True)
             self.step_labels.append(label)
@@ -125,6 +141,17 @@ class WizardController:
                 self.next_btn.configure(text=nav_t["next"])
         except Exception:
             pass
+        create_t = self._create_nav_texts(lang_code)
+        try:
+            if self.pause_btn.winfo_viewable():
+                # Не затираем «Продолжить», если сейчас на паузе
+                page = self.get_current_page()
+                if not (hasattr(page, "_paused") and page._paused):
+                    self.pause_btn.configure(text=create_t["pause"])
+            if self.cancel_btn.winfo_viewable():
+                self.cancel_btn.configure(text=create_t["cancel"])
+        except Exception:
+            pass
 
     def show_first_page(self):
         """Показать первую страницу."""
@@ -142,20 +169,26 @@ class WizardController:
             PageAPI,
             PageLogo,
             PageFile,
-            PageScope,
             PageComments,
+            PageScope,
             PageLaunch,
+            PageCreate,
         ]
 
         if index < 0 or index >= len(page_classes):
             return
 
         page_class = page_classes[index]
-        is_last = (index == len(page_classes) - 1)
+        is_create = index == len(page_classes) - 1
+        is_launch = index == len(page_classes) - 2
 
-        # Для последней страницы передаём on_complete (запуск pipeline),
-        # для остальных — _on_page_complete (сохранение данных)
-        page_callback = self.on_complete if is_last else self._on_page_complete
+        # Launch → переход на Создание; Создание → старт pipeline (on_complete)
+        if is_create:
+            page_callback = self.on_complete
+        elif is_launch:
+            page_callback = self._on_launch_clicked
+        else:
+            page_callback = self._on_page_complete
 
         # Для страницы языка передаём дополнительный колбэк смены языка
         kwargs = {}
@@ -169,25 +202,59 @@ class WizardController:
             **kwargs,
         )
         page.pack(fill="both", expand=True)
+        self._current_page = page
+
+        if is_create and hasattr(page, "set_nav_restore_callback"):
+            page.set_nav_restore_callback(self._restore_nav_after_create)
+        if is_create and hasattr(page, "bind_nav_controls"):
+            page.bind_nav_controls(self.pause_btn, self.cancel_btn)
 
         self.current_page_index = index
 
         # Обновляем индикатор шагов
         self._update_step_indicator(index)
 
-        # Обновляем кнопки навигации
-        self.back_btn.configure(
-            state="normal" if index > 0 else "disabled"
-        )
-
-        if is_last:
-            # На последней странице кнопка навигации не нужна —
-            # на самой странице есть зелёная кнопка запуска
+        # Навигация: на Создании — Пауза/Отмена вместо Далее; Назад выключен
+        if is_create:
             self.next_btn.pack_forget()
+            self.back_btn.configure(state="disabled")
+            create_t = self._create_nav_texts()
+            self.pause_btn.configure(text=create_t["pause"], state="normal")
+            self.cancel_btn.configure(text=create_t["cancel"], state="normal")
+            # side=right: первым пакуется правее
+            self.cancel_btn.pack(side="right", padx=10, pady=5)
+            self.pause_btn.pack(side="right", padx=10, pady=5)
         else:
+            self.pause_btn.pack_forget()
+            self.cancel_btn.pack_forget()
+            self.back_btn.configure(state="normal" if index > 0 else "disabled")
             self.next_btn.pack(side="right", padx=10, pady=5)
             nav_t = NAV_TEXTS.get(self.settings.ui_lang, NAV_TEXTS["ru"])
-            self.next_btn.configure(text=nav_t["next"])
+            self.next_btn.configure(
+                text=nav_t["next"],
+                fg_color=["#3B8ED0", "#1F6AA5"],
+                hover_color=["#36719F", "#144870"],
+            )
+
+    def _create_nav_texts(self, lang: Optional[str] = None) -> dict:
+        from src.ui.pages.page_create import CREATE_TEXTS
+        code = lang or self.settings.ui_lang
+        return CREATE_TEXTS.get(code, CREATE_TEXTS["ru"])
+
+    def _on_launch_clicked(self, *args, **kwargs):
+        """Совместимость: раньше зелёная кнопка на Запуске."""
+        self.go_next()
+
+    def _restore_nav_after_create(self):
+        """После завершения/отмены создания — стандартная «Назад» к Запуску."""
+        self.pause_btn.pack_forget()
+        self.cancel_btn.pack_forget()
+        self.next_btn.pack_forget()
+        self.back_btn.configure(state="normal")
+
+    def get_current_page(self):
+        """Текущая страница визарда."""
+        return getattr(self, "_current_page", None) or self._get_current_page()
 
     def _update_step_indicator(self, active_index: int):
         """Обновление подсветки активного шага."""
@@ -224,12 +291,10 @@ class WizardController:
             data = current_page.get_data()
             self._on_page_complete(data)
 
-        max_index = 6  # 7 страниц (0-6)
+        max_index = 7  # 8 страниц (0-7)
         if self.current_page_index < max_index:
             self._show_page(self.current_page_index + 1)
         else:
-            # Последняя страница — запуск
-            # Данные уже собраны через _on_page_complete выше
             if self.on_complete:
                 self.on_complete()
 

--- a/src/utils/scope_display.py
+++ b/src/utils/scope_display.py
@@ -1,0 +1,100 @@
+"""
+Форматирование объёма озвучки (полная книга / глава / диапазон)
+и коды этапов прогресса.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Этапы пайплайна (для UI вместо процента)
+STAGE_PREPARE = "prepare"
+STAGE_SYNTH = "synth"
+STAGE_CHAPTER_MERGE = "chapter_merge"
+STAGE_BOOK_MERGE = "book_merge"
+STAGE_DONE = "done"
+
+STAGE_LABELS = {
+    STAGE_PREPARE: "Подготовка…",
+    STAGE_SYNTH: "Синтез речи по главам",
+    STAGE_CHAPTER_MERGE: "Склеивание по главам",
+    STAGE_BOOK_MERGE: "Склеивание книги суммарно",
+    STAGE_DONE: "Готово",
+}
+
+SCOPE_TEXTS = {
+    "ru": {
+        "all": "Полный",
+        "single": "Глава {}",
+        "range": "Главы с {} по {}",
+        "total": "всего глав {}",
+        "current": "Глава {}",
+    },
+    "en": {
+        "all": "Full book",
+        "single": "Chapter {}",
+        "range": "Chapters {}–{}",
+        "total": "total chapters {}",
+        "current": "Chapter {}",
+    },
+    "ja": {
+        "all": "全章",
+        "single": "第{}章",
+        "range": "第{}章〜第{}章",
+        "total": "総章数 {}",
+        "current": "第{}章",
+    },
+    "zh": {
+        "all": "全书",
+        "single": "第{}章",
+        "range": "第{}章至第{}章",
+        "total": "总章节 {}",
+        "current": "第{}章",
+    },
+}
+
+
+def format_scope(
+    chapter_start: int,
+    chapter_end: int,
+    total_chapters: Optional[int] = None,
+    lang: str = "ru",
+) -> str:
+    """Краткое описание режима объёма по chapter_start/chapter_end.
+
+    chapter_start/end — как в Settings/pipeline:
+    (0, 0) = вся книга; иначе start 0-based, end exclusive (1-based в UI).
+    """
+    t = SCOPE_TEXTS.get(lang, SCOPE_TEXTS["ru"])
+    start = int(chapter_start or 0)
+    end = int(chapter_end or 0)
+
+    if start == 0 and end == 0:
+        return t["all"]
+    if end == start + 1:
+        return t["single"].format(start + 1)
+
+    from_ch = start + 1
+    to_ch = end if end > 0 else (total_chapters or from_ch)
+    return t["range"].format(from_ch, to_ch)
+
+
+def format_progress_scope_line(
+    *,
+    chapter_current: Optional[int],
+    chapter_start: int,
+    chapter_end: int,
+    total_chapters: int,
+    lang: str = "ru",
+) -> str:
+    """Строка для окна прогресса: текущая глава + режим + всего глав."""
+    t = SCOPE_TEXTS.get(lang, SCOPE_TEXTS["ru"])
+    scope = format_scope(chapter_start, chapter_end, total_chapters, lang)
+    parts = []
+    # При режиме «одна глава» scope уже содержит «Глава N» — не дублируем
+    single = int(chapter_end or 0) == int(chapter_start or 0) + 1 and int(chapter_end or 0) > 0
+    if chapter_current is not None and chapter_current > 0 and not single:
+        parts.append(t["current"].format(chapter_current))
+    parts.append(scope)
+    parts.append(t["total"].format(total_chapters))
+    return " · ".join(parts)


### PR DESCRIPTION
_(рекомендуется после остальных моих МР)_

### Summary

Прогресс создания перенесён из модального ProgressWindow в шаг 8 «Создание» визарда: единый поток настройки → запуск → синтез без отдельного окна.

Pipeline разбит на фазы (подготовка / синтез по сегментам / склейка глав / склейка книги), с pre-split глав диапазона и общим счётчиком сегментов.

На «Запуске» убрана зелёная кнопка: дальше — синяя «Далее →»; Пауза / Отмена — в нижней панели на шаге создания.

ETA синтеза: скрытый таймер с начала синтеза, после каждого сегмента (время / готово) × осталось.
UI шага «Создание»: title «Создание аудиокниги» как на других шагах; два блока — «Синтез речи по главам» и «Склеивание по главам» (каждый со своим progress/ETA).

Склейка глав: прогресс и ETA по каждому сегменту (fragment_callback в AudioAssembler); в статусе везде «сегмент», не «фрагмент».

Подписи объёма/этапов вынесены в scope_display.

### Почему так

Модальный прогресс ломал модель мастера. После настройки нужен тот же wizard-flow, а не dialog поверх UI. Шаг «Создание» сохраняет индикатор шагов и упрощает возврат на «Запуск».

Общий % по всему pipeline плохо отражал реальность. TTS и ffmpeg-склейка доминируют по времени по-разному. Pre-split + счётчик сегментов и отдельный ETA на этап дают честную оценку.

Единый блок прогресса смешивал этапы. Title внутри карточки рядом с названием фазы путал иерархию. Title страницы + два стабильных блока читаются как: страница → синтез → склейка.

Склейка тоже мелкозернистая и долгая. Обновление раз в главу оставляло «Осталось» бессмысленным; нужен тот же контракт, что у синтеза — сегмент за сегментом.

Зелёная «Создать» на Запуске дублировала навигацию; достаточно «Далее →» на шаг, где процесс стартует сам.