### PR TITLE
feat(tts): битрейт MP3 по движку — дропдаун и CBR в финальной склейке

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -32,6 +32,8 @@ class Settings:
 
     # TTS бэкенд
     tts_backend: str = "edge"  # "edge" | "piper" | "supertonic" | "silero"
+    # Битрейт MP3 (kbps); для Edge всегда 48
+    tts_bitrate_kbps: int = 48
 
     # Пол голосов TTS (резолвятся в имена через движок + язык книги)
     main_gender: str = "female"
@@ -148,6 +150,11 @@ def load_settings(config_path: Optional[Path] = None) -> Settings:
         filtered_data = {k: v for k, v in data.items() if k in known_fields}
 
         settings = Settings(**filtered_data)
+        # Битрейт должен быть допустим для выбранного движка
+        from src.core.audio_bitrate import clamp_bitrate
+        settings.tts_bitrate_kbps = clamp_bitrate(
+            settings.tts_backend, int(settings.tts_bitrate_kbps or 0),
+        )
         logger.info("Настройки загружены: %s", path)
         return settings
 

--- a/src/core/audio_assembler.py
+++ b/src/core/audio_assembler.py
@@ -16,6 +16,8 @@ import tempfile
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
+from src.core.audio_bitrate import ffmpeg_lame_bitrate_args
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +38,7 @@ class AudioAssembler:
         )
     """
 
-    def __init__(self, sample_rate: int = 22050):
+    def __init__(self, sample_rate: int = 22050, bitrate_kbps: int = 128):
         """Инициализация AudioAssembler.
 
         Args:
@@ -45,8 +47,10 @@ class AudioAssembler:
                 Edge TTS (через ffmpeg) будет передискретизирован под эту частоту
                 при склейке, что обеспечивает консистентность всех аудиофрагментов
                 и предотвращает белый шум из-за mismatch в ffmpeg concat demuxer.
+            bitrate_kbps: Битрейт финального MP3 (CBR).
         """
         self.sample_rate = sample_rate
+        self.bitrate_kbps = int(bitrate_kbps) or 128
         self._ffmpeg = self._find_ffmpeg()
 
     # ── helpers ────────────────────────────────────────────────
@@ -229,12 +233,10 @@ class AudioAssembler:
                 "-y", str(merged_wav),
             ])
 
-            # Финальное кодирование в MP3
+            # Финальное кодирование в MP3 (явный CBR без -q:a)
             self._run_ffmpeg([
                 "-i", str(merged_wav),
-                "-codec:a", "libmp3lame",
-                "-b:a", "192k",
-                "-q:a", "0",
+                *ffmpeg_lame_bitrate_args(self.bitrate_kbps),
                 "-y", str(output_path),
             ])
 

--- a/src/core/audio_bitrate.py
+++ b/src/core/audio_bitrate.py
@@ -1,0 +1,77 @@
+"""
+Битрейт MP3 по TTS-движкам: что поддерживается и аргументы ffmpeg.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+# Поддерживаемые значения (kbps) для каждого бэкенда.
+# Edge: Microsoft жёстко отдаёт audio-24khz-48kbitrate-mono-mp3.
+TTS_BITRATE_OPTIONS_KBPS: Dict[str, List[int]] = {
+    "edge": [48],
+    "piper": [48, 64, 96, 128, 192],
+    "silero": [48, 64, 96, 128, 192],
+    "supertonic": [48, 64, 96, 128, 192],
+}
+
+TTS_BITRATE_DEFAULT_KBPS: Dict[str, int] = {
+    "edge": 48,
+    "piper": 128,
+    "silero": 128,
+    "supertonic": 128,
+}
+
+
+def supported_bitrates(backend: str) -> List[int]:
+    """Список доступных битрейтов (kbps) для движка."""
+    return list(TTS_BITRATE_OPTIONS_KBPS.get(backend, TTS_BITRATE_OPTIONS_KBPS["edge"]))
+
+
+def default_bitrate(backend: str) -> int:
+    """Битрейт по умолчанию для движка."""
+    return TTS_BITRATE_DEFAULT_KBPS.get(backend, 128)
+
+
+def clamp_bitrate(backend: str, kbps: int) -> int:
+    """Привести выбранный битрейт к допустимому для движка."""
+    options = supported_bitrates(backend)
+    if not options:
+        return 48
+    if kbps in options:
+        return kbps
+    # ближайший снизу, иначе дефолт
+    lower = [o for o in options if o <= kbps]
+    if lower:
+        return max(lower)
+    return default_bitrate(backend)
+
+
+def bitrate_menu_labels(backend: str, lang: str = "ru") -> List[str]:
+    """Подписи для OptionMenu: «48 kbps», для Edge — пометка о фиксации."""
+    fixed_note = {
+        "ru": " (фиксировано Edge)",
+        "en": " (fixed by Edge)",
+        "ja": " (Edge固定)",
+        "zh": "（Edge固定）",
+    }.get(lang, " (фиксировано Edge)")
+    labels = []
+    for kbps in supported_bitrates(backend):
+        label = f"{kbps} kbps"
+        if backend == "edge":
+            label += fixed_note
+        labels.append(label)
+    return labels
+
+
+def parse_bitrate_label(label: str) -> int:
+    """Извлечь kbps из подписи меню."""
+    try:
+        return int(str(label).split()[0])
+    except (ValueError, IndexError):
+        return 48
+
+
+def ffmpeg_lame_bitrate_args(kbps: int) -> List[str]:
+    """Аргументы libmp3lame с явным CBR (без -q:a, чтобы не конфликтовать с -b:a)."""
+    return ["-codec:a", "libmp3lame", "-b:a", f"{int(kbps)}k"]

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -18,6 +18,7 @@ from .sentence_splitter import SentenceSplitter
 from .comment_manager import CommentManager, CommentConfig
 from .tts_manager import TTSManager, TTSConfig
 from .audio_assembler import AudioAssembler
+from .audio_bitrate import clamp_bitrate
 from .checkpoint_manager import CheckpointManager, Checkpoint
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,11 @@ class Pipeline:
         self.sentence_splitter = SentenceSplitter()
         self.comment_manager = CommentManager(config.comment_config)
         self.tts_manager = TTSManager(config.tts_config)
-        self.audio_assembler = AudioAssembler()
+        bitrate = clamp_bitrate(
+            config.tts_config.backend,
+            int(getattr(config.tts_config, "audio_bitrate_kbps", 0) or 0),
+        )
+        self.audio_assembler = AudioAssembler(bitrate_kbps=bitrate)
         self.checkpoint_manager = CheckpointManager(config.work_dir)
 
         self._book: Optional[ParsedBook] = None

--- a/src/core/tts_manager.py
+++ b/src/core/tts_manager.py
@@ -71,6 +71,8 @@ class TTSConfig:
     pause_before_comment: float = 1.0  # секунд тишины перед комментарием
     pause_after_comment: float = 0.7  # секунд тишины после комментария
     pause_between_sentences: float = 0.3  # пауза между предложениями
+    # Битрейт сегментов и финального MP3 (kbps). Edge-сегменты всегда 48.
+    audio_bitrate_kbps: int = 48
 
 
 # Словарь для обратной связи backend → читаемое название

--- a/src/core/tts_piper.py
+++ b/src/core/tts_piper.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from src.core.audio_bitrate import clamp_bitrate, ffmpeg_lame_bitrate_args
 from src.core.tts_base import TTSBackend
 
 logger = logging.getLogger(__name__)
@@ -309,6 +310,13 @@ class PiperTTSManager(TTSBackend):
         except asyncio.TimeoutError:
             raise RuntimeError("Piper TTS превысил таймаут (60 сек)")
 
+    def _mp3_codec_args(self) -> list:
+        kbps = clamp_bitrate(
+            getattr(self.config, "backend", "piper"),
+            int(getattr(self.config, "audio_bitrate_kbps", 0) or 0),
+        )
+        return ffmpeg_lame_bitrate_args(kbps)
+
     async def _generate_silence_mp3(
         self, output_path: Path, duration_sec: float = 0.5
     ) -> None:
@@ -328,7 +336,7 @@ class PiperTTSManager(TTSBackend):
             "ffmpeg", "-y",
             "-f", "lavfi", "-i", "anullsrc=r=22050:cl=mono",
             "-t", str(duration_sec),
-            "-acodec", "libmp3lame", "-q:a", "2",
+            *self._mp3_codec_args(),
             str(output_path),
         ]
         process = await asyncio.create_subprocess_exec(
@@ -366,7 +374,7 @@ class PiperTTSManager(TTSBackend):
             cmd = [
                 "ffmpeg", "-y", "-i", str(wav_path),
                 "-ar", "22050",
-                "-codec:a", "libmp3lame", "-q:a", "2",
+                *self._mp3_codec_args(),
                 str(output_path),
             ]
         else:
@@ -378,7 +386,7 @@ class PiperTTSManager(TTSBackend):
                 "ffmpeg", "-y", "-i", str(wav_path),
                 "-ar", "22050",
                 "-filter:a", filter_str,
-                "-codec:a", "libmp3lame", "-q:a", "2",
+                *self._mp3_codec_args(),
                 str(output_path),
             ]
 

--- a/src/core/tts_silero.py
+++ b/src/core/tts_silero.py
@@ -21,6 +21,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from src.core.audio_bitrate import clamp_bitrate, ffmpeg_lame_bitrate_args
 from src.core.tts_base import TTSBackend
 
 logger = logging.getLogger(__name__)
@@ -268,13 +269,20 @@ class SileroTTSManager(TTSBackend):
         )
         return mp3_path
 
+    def _mp3_codec_args(self) -> list:
+        kbps = clamp_bitrate(
+            getattr(self.config, "backend", "silero"),
+            int(getattr(self.config, "audio_bitrate_kbps", 0) or 0),
+        )
+        return ffmpeg_lame_bitrate_args(kbps)
+
     async def _generate_silence_mp3(self, output_path: Path, duration_sec: float = 0.5):
         """Сгенерировать тишину через ffmpeg."""
         cmd = [
             "ffmpeg", "-y",
             "-f", "lavfi", "-i", "anullsrc=r=22050:cl=mono",
             "-t", str(duration_sec),
-            "-acodec", "libmp3lame", "-q:a", "2",
+            *self._mp3_codec_args(),
             str(output_path),
         ]
         process = await asyncio.create_subprocess_exec(
@@ -295,7 +303,7 @@ class SileroTTSManager(TTSBackend):
             cmd = [
                 "ffmpeg", "-y", "-i", str(wav_path),
                 "-ar", "22050",
-                "-codec:a", "libmp3lame", "-q:a", "2",
+                *self._mp3_codec_args(),
                 str(output_path),
             ]
         else:
@@ -303,7 +311,7 @@ class SileroTTSManager(TTSBackend):
                 "ffmpeg", "-y", "-i", str(wav_path),
                 "-ar", "22050",
                 "-filter:a", f"atempo={speed}",
-                "-codec:a", "libmp3lame", "-q:a", "2",
+                *self._mp3_codec_args(),
                 str(output_path),
             ]
 

--- a/src/core/tts_supertonic.py
+++ b/src/core/tts_supertonic.py
@@ -17,6 +17,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from src.core.audio_bitrate import clamp_bitrate, ffmpeg_lame_bitrate_args
 from src.core.tts_base import TTSBackend
 
 logger = logging.getLogger(__name__)
@@ -194,13 +195,20 @@ class SupertonicTTSManager(TTSBackend):
         )
         return mp3_path
 
+    def _mp3_codec_args(self) -> list:
+        kbps = clamp_bitrate(
+            getattr(self.config, "backend", "supertonic"),
+            int(getattr(self.config, "audio_bitrate_kbps", 0) or 0),
+        )
+        return ffmpeg_lame_bitrate_args(kbps)
+
     async def _generate_silence_mp3(self, output_path: Path, duration_sec: float = 0.5):
         """Сгенерировать тишину через ffmpeg."""
         cmd = [
             "ffmpeg", "-y",
             "-f", "lavfi", "-i", "anullsrc=r=22050:cl=mono",
             "-t", str(duration_sec),
-            "-acodec", "libmp3lame", "-q:a", "2",
+            *self._mp3_codec_args(),
             str(output_path),
         ]
         process = await asyncio.create_subprocess_exec(
@@ -221,7 +229,7 @@ class SupertonicTTSManager(TTSBackend):
             cmd = [
                 "ffmpeg", "-y", "-i", str(wav_path),
                 "-ar", "22050",
-                "-codec:a", "libmp3lame", "-q:a", "2",
+                *self._mp3_codec_args(),
                 str(output_path),
             ]
         else:
@@ -229,7 +237,7 @@ class SupertonicTTSManager(TTSBackend):
                 "ffmpeg", "-y", "-i", str(wav_path),
                 "-ar", "22050",
                 "-filter:a", f"atempo={speed}",
-                "-codec:a", "libmp3lame", "-q:a", "2",
+                *self._mp3_codec_args(),
                 str(output_path),
             ]
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -20,6 +20,7 @@ from src.config.key_manager import KeyManager
 from src.core.comment_manager import CommentConfig
 from src.core.pipeline import AppConfig, Pipeline
 from src.core.tts_manager import TTSConfig, resolve_voice
+from src.core.audio_bitrate import clamp_bitrate
 from src.ui.progress_window import ProgressWindow
 from src.ui.wizard import WizardController
 
@@ -320,6 +321,10 @@ class AudiobookApp(ctk.CTk):
                 pause_before_comment=self.settings.pause_before_comment,
                 pause_after_comment=self.settings.pause_after_comment,
                 pause_between_sentences=self.settings.pause_between_sentences,
+                audio_bitrate_kbps=clamp_bitrate(
+                    self.settings.tts_backend,
+                    int(getattr(self.settings, "tts_bitrate_kbps", 0) or 0),
+                ),
             )
 
             config = AppConfig(

--- a/src/ui/pages/page_comments.py
+++ b/src/ui/pages/page_comments.py
@@ -12,6 +12,11 @@ import tomllib as tomli
 import customtkinter as ctk
 
 from src.config.settings import Settings
+from src.core.audio_bitrate import (
+    bitrate_menu_labels,
+    clamp_bitrate,
+    parse_bitrate_label,
+)
 from src.core.tts_manager import resolve_voice
 
 logger = logging.getLogger(__name__)
@@ -28,6 +33,8 @@ COMMENTS_TEXTS = {
         "custom_label": "Или введите свой системный промпт:",
         "tts_label": "TTS движок:",
         "tts_desc": "Edge TTS — облачный, высокое качество, возможны сбои.\\nPiper — локальный, на CPU, без интернета, чуть ниже качество.\\nSupertonic 3 — локальный, отличное качество, 31 язык, ~305 МБ.\\nSilero TTS v5 — локальный, лучшее качество русского среди open-source.",
+        "bitrate_label": "Битрейт аудио:",
+        "bitrate_desc": "Для Edge фиксирован Microsoft (48 kbps). Для локальных движков — сегменты и финальный MP3.",
         "gender_main_label": "Пол основного голоса:",
         "gender_comment_label": "Пол голоса комментатора:",
         "gender_male": "Мужской",
@@ -43,6 +50,8 @@ COMMENTS_TEXTS = {
         "custom_label": "Or enter your own system prompt:",
         "tts_label": "TTS engine:",
         "tts_desc": "Edge TTS — cloud-based, high quality, but may have outages.\\nPiper — local, CPU-only, no internet needed, slightly lower quality.\\nSupertonic 3 — local, high quality, 31 languages, ~305 MB.\\nSilero TTS v5 — local, best russian quality among open-source.",
+        "bitrate_label": "Audio bitrate:",
+        "bitrate_desc": "Edge is fixed by Microsoft (48 kbps). For local engines — segments and final MP3.",
         "gender_main_label": "Main voice gender:",
         "gender_comment_label": "Comment voice gender:",
         "gender_male": "Male",
@@ -58,6 +67,8 @@ COMMENTS_TEXTS = {
         "custom_label": "または独自のシステムプロンプトを入力:",
         "tts_label": "TTSエンジン:",
         "tts_desc": "Edge TTS — クラウド、高品質だが障害の可能性あり。\\nPiper — ローカル、CPU動作、オフラインでも使用可能。\\nSupertonic 3 — ローカル、高品質、31言語、~305 MB。\\nSilero TTS v5 — ローカル、ロシア語に最適なオープンソースTTS。",
+        "bitrate_label": "ビットレート:",
+        "bitrate_desc": "EdgeはMicrosoft固定（48 kbps）。ローカルエンジンはセグメントと最終MP3に適用。",
         "gender_main_label": "本文声の性別:",
         "gender_comment_label": "コメント声の性別:",
         "gender_male": "男性",
@@ -73,6 +84,8 @@ COMMENTS_TEXTS = {
         "custom_label": "或输入您自己的系统提示：",
         "tts_label": "TTS引擎：",
         "tts_desc": "Edge TTS — 云端，高质量，但可能中断。\\nPiper — 本地，CPU运行，无需网络，质量稍低。\\nSupertonic 3 — 本地，高质量，31种语言，~305 MB。\\nSilero TTS v5 — 本地，开源中俄语质量最佳。",
+        "bitrate_label": "音频比特率：",
+        "bitrate_desc": "Edge由Microsoft固定（48 kbps）。本地引擎用于片段和最终MP3。",
         "gender_main_label": "正文语音性别：",
         "gender_comment_label": "评论语音性别：",
         "gender_male": "男",
@@ -244,6 +257,42 @@ class PageComments(ctk.CTkFrame):
         )
         self.tts_desc_label.pack(anchor="w", padx=10, pady=(0, 10))
 
+        ctk.CTkLabel(
+            tts_frame,
+            text=t["bitrate_label"],
+            font=ctk.CTkFont(size=14),
+        ).pack(anchor="w", padx=10, pady=(5, 5))
+
+        initial_backend = self.tts_backend_var.get()
+        initial_kbps = clamp_bitrate(
+            initial_backend, int(getattr(self.settings, "tts_bitrate_kbps", 0) or 0),
+        )
+        bitrate_values = bitrate_menu_labels(initial_backend, lang)
+        self.bitrate_var = ctk.StringVar(
+            value=next(
+                (v for v in bitrate_values if v.startswith(f"{initial_kbps} ")),
+                bitrate_values[0],
+            )
+        )
+        self.bitrate_menu = ctk.CTkOptionMenu(
+            tts_frame,
+            values=bitrate_values,
+            variable=self.bitrate_var,
+            width=300,
+            state="disabled" if initial_backend == "edge" else "normal",
+        )
+        self.bitrate_menu.pack(anchor="w", padx=10, pady=(0, 5))
+
+        self.bitrate_desc_label = ctk.CTkLabel(
+            tts_frame,
+            text=t["bitrate_desc"],
+            font=ctk.CTkFont(size=12),
+            text_color="gray",
+            wraplength=500,
+            justify="left",
+        )
+        self.bitrate_desc_label.pack(anchor="w", padx=10, pady=(0, 10))
+
         # --- Пол голоса ---
         gender_frame = ctk.CTkFrame(self)
         gender_frame.pack(fill="x", padx=40, pady=10)
@@ -365,21 +414,31 @@ class PageComments(ctk.CTkFrame):
                     child.configure(state=state)
 
     def _on_tts_backend_change(self, backend: str):
-        """Обработчик выбора TTS движка."""
+        """Обработчик выбора TTS движка — обновить список битрейтов."""
         lang = self.settings.ui_lang
-        t = COMMENTS_TEXTS.get(lang, COMMENTS_TEXTS["ru"])
-        # Описание обновляется автоматически при переключении
+        current = parse_bitrate_label(self.bitrate_var.get())
+        kbps = clamp_bitrate(backend, current)
+        values = bitrate_menu_labels(backend, lang)
+        self.bitrate_menu.configure(
+            values=values,
+            state="disabled" if backend == "edge" else "normal",
+        )
+        label = next((v for v in values if v.startswith(f"{kbps} ")), values[0])
+        self.bitrate_var.set(label)
 
     def get_data(self) -> dict:
         """Сбор данных со страницы."""
         frequency = int(self.frequency_var.get())
         system_prompt = self.custom_prompt_text.get("1.0", "end-1c").strip()
+        backend = self.tts_backend_var.get()
+        bitrate = clamp_bitrate(backend, parse_bitrate_label(self.bitrate_var.get()))
 
         return {
             "comment_enabled": self.comments_enabled_var.get(),
             "comment_frequency": frequency,
             "system_prompt": system_prompt,
-            "tts_backend": self.tts_backend_var.get(),
+            "tts_backend": backend,
+            "tts_bitrate_kbps": bitrate,
             "main_gender": self.main_gender_var.get(),
             "comment_gender": self.comment_gender_var.get(),
         }


### PR DESCRIPTION
### Summary

На шаге комментариев добавлен дропдаун «Битрейт аудио», список зависит от TTS: Edge — только 48 kbps (disabled, фиксировано Microsoft); Silero / Piper / Supertonic — 48 / 64 / 96 / 128 / 192 kbps. Настройка сохраняется в tts_bitrate_kbps и прокидывается в TTSConfig. Локальные движки кодируют сегменты выбранным CBR (-b:a Nk, без конфликтующего -q:a). Финальный assemble_book кодирует книгу тем же битрейтом (явный CBR). Добавлен модуль audio_bitrate.py (опции, clamp, подписи UI, аргументы ffmpeg). 

### Почему так

Edge нельзя «поднять» выше 48 kbps — формат задаёт облако. Локальные TTS раньше писали сегменты с -q:a 2 (тяжёлый VBR), а финал смешивал -b:a 192k и -q:a 0, из‑за чего реальный битрейт книги уезжал (~70 kbps) и не совпадал с ожиданиями.

Один выбор в UI даёт предсказуемый размер и качество: сегменты и финал в одном CBR, список опций не предлагает невозможного для Edge.